### PR TITLE
feat(#3): add Quarterly and Half-Yearly as first-class billing cycles

### DIFF
--- a/apps/backend/pb_hooks/lib/date-helpers.js
+++ b/apps/backend/pb_hooks/lib/date-helpers.js
@@ -1,7 +1,7 @@
 /**
  * Advances a date by the given cycle and frequency.
  * @param {Date} date
- * @param {string} cycleName - "Daily" | "Weekly" | "Monthly" | "Yearly"
+ * @param {string} cycleName - "Daily" | "Weekly" | "Monthly" | "Quarterly" | "Half-Yearly" | "Yearly"
  * @param {number} frequency - multiplier
  * @returns {Date}
  */
@@ -17,6 +17,14 @@ function advanceDate(date, cycleName, frequency) {
       break;
     case "Monthly":
       result.setMonth(result.getMonth() + frequency);
+      break;
+    case "Quarterly":
+      // 1 quarter = 3 months
+      result.setMonth(result.getMonth() + frequency * 3);
+      break;
+    case "Half-Yearly":
+      // 1 half-year = 6 months
+      result.setMonth(result.getMonth() + frequency * 6);
       break;
     case "Yearly":
       result.setFullYear(result.getFullYear() + frequency);
@@ -44,6 +52,12 @@ function getPricePerMonth(price, cycleName, frequency, exchangeRate) {
       return (converted / frequency) * 4.33;
     case "Monthly":
       return converted / frequency;
+    case "Quarterly":
+      // Price is charged every (frequency * 3) months
+      return converted / (frequency * 3);
+    case "Half-Yearly":
+      // Price is charged every (frequency * 6) months
+      return converted / (frequency * 6);
     case "Yearly":
       return converted / (frequency * 12);
     default:

--- a/apps/backend/pb_hooks/routes_chat.pb.js
+++ b/apps/backend/pb_hooks/routes_chat.pb.js
@@ -168,7 +168,7 @@ routerAdd("POST", "/api/ai/chat", function (e) {
           "cycles", "name = {:name}", "", 1, 0,
           { name: args.cycle }
         );
-        if (cycles.length === 0) return { error: "Cycle not found: " + args.cycle + ". Use: Daily, Weekly, Monthly, or Yearly." };
+        if (cycles.length === 0) return { error: "Cycle not found: " + args.cycle + ". Use: Daily, Weekly, Monthly, Quarterly, Half-Yearly, or Yearly." };
         sub.set("cycle", cycles[0].id);
       }
 
@@ -437,7 +437,7 @@ routerAdd("POST", "/api/ai/chat", function (e) {
         if (cycles.length > 0) cycleId = cycles[0].id;
       } catch (_) { }
       if (!cycleId) {
-        return { error: "Cycle not found: " + args.cycle + ". Use: Daily, Weekly, Monthly, or Yearly." };
+        return { error: "Cycle not found: " + args.cycle + ". Use: Daily, Weekly, Monthly, Quarterly, Half-Yearly, or Yearly." };
       }
 
       var categoryId = "";
@@ -1464,7 +1464,7 @@ routerAdd("POST", "/api/ai/chat", function (e) {
 
       glossary:
         "**Zublo glossary:**\n\n" +
-        "- **Cycle**: billing period unit — Daily, Weekly, Monthly, or Yearly.\n" +
+        "- **Cycle**: billing period unit — Daily, Weekly, Monthly, Quarterly, Half-Yearly, or Yearly.\n" +
         "- **Frequency**: how many cycles between charges (default 1). Frequency=3 + Cycle=Monthly = quarterly billing.\n" +
         "- **Next payment**: date the next charge is expected. Advances automatically when payment is recorded.\n" +
         "- **Start date**: when the subscription began. Used for progress bars and history.\n" +

--- a/apps/backend/pb_migrations/0020_add_quarterly_half_yearly_cycles.js
+++ b/apps/backend/pb_migrations/0020_add_quarterly_half_yearly_cycles.js
@@ -1,0 +1,85 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Migration 0020 — Add Quarterly and Half-Yearly billing cycles.
+ *
+ * Previously, quarterly / half-yearly subscriptions were approximated with
+ * Monthly cycle + frequency=3 or 6.  This migration promotes them to
+ * first-class cycles with their own seed frequencies so the UI can offer
+ * them as explicit options.
+ *
+ * Safe to run on existing installs: it skips cycle creation when the name
+ * already exists, so re-running or deploying on a fresh instance is
+ * idempotent.
+ */
+
+migrate(
+  (app) => {
+    const cyclesCol = app.findCollectionByNameOrId("cycles");
+    const freqCol = app.findCollectionByNameOrId("frequencies");
+
+    const newCycles = [
+      {
+        name: "Quarterly",
+        frequencies: [
+          { name: "Every quarter", value: 1 },
+          { name: "Every 2 quarters", value: 2 },
+          { name: "Every 3 quarters", value: 3 },
+          { name: "Every 4 quarters", value: 4 },
+        ],
+      },
+      {
+        name: "Half-Yearly",
+        frequencies: [
+          { name: "Every half-year", value: 1 },
+          { name: "Every year (half-yearly)", value: 2 },
+        ],
+      },
+    ];
+
+    for (const cycleDef of newCycles) {
+      // Idempotency: skip if the cycle already exists
+      const existing = app.findRecordsByFilter(
+        "cycles", "name = {:name}", "", 1, 0, { name: cycleDef.name }
+      );
+      if (existing.length > 0) {
+        console.log("[Zublo] Migration 0020: cycle '" + cycleDef.name + "' already exists, skipping.");
+        continue;
+      }
+
+      const cycleRecord = new Record(cyclesCol);
+      cycleRecord.set("name", cycleDef.name);
+      app.save(cycleRecord);
+      const cycleId = cycleRecord.id;
+
+      for (const freq of cycleDef.frequencies) {
+        const freqRecord = new Record(freqCol);
+        freqRecord.set("name", freq.name);
+        freqRecord.set("value", freq.value);
+        freqRecord.set("cycle", cycleId);
+        app.save(freqRecord);
+      }
+
+      console.log("[Zublo] Migration 0020: added cycle '" + cycleDef.name + "' with " + cycleDef.frequencies.length + " frequencies.");
+    }
+  },
+
+  // DOWN — remove the cycles (and let cascade delete remove their frequencies)
+  (app) => {
+    for (const name of ["Quarterly", "Half-Yearly"]) {
+      try {
+        const records = app.findRecordsByFilter(
+          "cycles", "name = {:name}", "", 1, 0, { name }
+        );
+        if (records.length > 0) {
+          // Remove linked frequencies first to avoid foreign-key issues
+          const freqs = app.findRecordsByFilter(
+            "frequencies", "cycle = {:cid}", "", 0, 0, { cid: records[0].id }
+          );
+          for (const f of freqs) app.delete(f);
+          app.delete(records[0]);
+        }
+      } catch (_) {}
+    }
+  }
+);

--- a/apps/backend/tests/pb_hooks/date-helpers.test.js
+++ b/apps/backend/tests/pb_hooks/date-helpers.test.js
@@ -11,7 +11,7 @@ describe("pb_hooks/lib/date-helpers.js", () => {
     expect(result.toISOString()).toBe("2026-02-02T00:00:00.000Z");
   });
 
-  it("handles daily, weekly, monthly, and yearly cycles", () => {
+  it("handles daily, weekly, monthly, quarterly, half-yearly, and yearly cycles", () => {
     expect(
       advanceDate(new Date("2026-03-01T00:00:00.000Z"), "Daily", 3).toISOString(),
     ).toBe("2026-03-04T00:00:00.000Z");
@@ -21,6 +21,18 @@ describe("pb_hooks/lib/date-helpers.js", () => {
     expect(
       advanceDate(new Date("2026-01-31T00:00:00.000Z"), "Monthly", 1).toISOString(),
     ).toBe("2026-03-03T00:00:00.000Z");
+    // Quarterly: 1 quarter = 3 months
+    expect(
+      advanceDate(new Date("2026-01-01T00:00:00.000Z"), "Quarterly", 1).toISOString(),
+    ).toBe("2026-04-01T00:00:00.000Z");
+    // Quarterly with frequency=2: 2 quarters = 6 months
+    expect(
+      advanceDate(new Date("2026-01-01T00:00:00.000Z"), "Quarterly", 2).toISOString(),
+    ).toBe("2026-07-01T00:00:00.000Z");
+    // Half-Yearly: 1 half-year = 6 months
+    expect(
+      advanceDate(new Date("2026-01-01T00:00:00.000Z"), "Half-Yearly", 1).toISOString(),
+    ).toBe("2026-07-01T00:00:00.000Z");
     expect(
       advanceDate(new Date("2024-02-29T00:00:00.000Z"), "Yearly", 1).toISOString(),
     ).toBe("2025-03-01T00:00:00.000Z");
@@ -30,6 +42,12 @@ describe("pb_hooks/lib/date-helpers.js", () => {
     expect(getPricePerMonth(10, "Daily", 1, 1)).toBe(300);
     expect(getPricePerMonth(21, "Weekly", 3, 1)).toBeCloseTo(30.31, 2);
     expect(getPricePerMonth(24, "Monthly", 2, 1)).toBe(12);
+    // Quarterly: $90 every quarter (3 months) → $30/month
+    expect(getPricePerMonth(90, "Quarterly", 1, 1)).toBe(30);
+    // Quarterly with frequency=2: $90 every 2 quarters (6 months) → $15/month
+    expect(getPricePerMonth(90, "Quarterly", 2, 1)).toBe(15);
+    // Half-Yearly: $60 every half-year (6 months) → $10/month
+    expect(getPricePerMonth(60, "Half-Yearly", 1, 1)).toBe(10);
     expect(getPricePerMonth(120, "Yearly", 2, 1)).toBe(5);
   });
 

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -29,6 +29,8 @@
   "admin": "Admin",
   "about": "About",
   "monthly": "Monthly",
+  "quarterly": "Quarterly",
+  "half_yearly": "Half-Yearly",
   "yearly": "Yearly",
   "weekly": "Weekly",
   "daily": "Daily",

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -103,7 +103,7 @@ export interface Household {
 
 export interface Cycle {
   id: string;
-  name: "Daily" | "Weekly" | "Monthly" | "Yearly";
+  name: "Daily" | "Weekly" | "Monthly" | "Quarterly" | "Half-Yearly" | "Yearly";
 }
 
 export interface Frequency {


### PR DESCRIPTION
Previously, quarterly and half-yearly subscriptions could only be represented as Monthly cycle + frequency=3 or 6. This feature promotes them to first-class cycles, making the UI selection unambiguous and the subscription data self-describing. #3 