### PR TITLE
refactor: change the bind mount volume to use a dedicated volume 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,13 @@ services:
     environment:
       PB_ENCRYPTION_KEY: ${PB_ENCRYPTION_KEY}
     volumes:
-      - /srv/apps/zublo/data:/pb/pb_data #change this path to your desired path
+      - zublo-volume:/pb/pb_data
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9597/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 15s
+
+volumes:
+  zublo-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       PB_ENCRYPTION_KEY: ${PB_ENCRYPTION_KEY}
     volumes:
-      - zublo-volume:/pb/pb_data
+      - zublo-volume:/pb/pb_data # Persistent data stored in a Docker named volume (Windows/WSL friendly). If upgrading from a bind mount, migrate existing pb_data into this volume; replace with /path:/pb/pb_data to use a bind mount.
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9597/api/health"]
       interval: 30s


### PR DESCRIPTION
had a problem with that in windows , as its use wsl , and each run of docker containers or restart refresh recreate the folder and refresh the volume ( i lost my data after restart my pc )