### PR TITLE
fix(calendar): hide subscription occurrences before the start date

### DIFF
--- a/apps/web/src/components/calendar/types.test.ts
+++ b/apps/web/src/components/calendar/types.test.ts
@@ -16,6 +16,7 @@ import {
   getLogoUrl,
   getOccurrencesInMonth,
   getPaymentRecord,
+  parseLocalDate,
   toDateOnly,
   toDateStr,
   toMain,
@@ -330,6 +331,27 @@ describe("calendar types helpers", () => {
     );
     // With freq=1 and monthly cycle, exactly one occurrence in March
     expect(result).toHaveLength(1);
+  });
+
+  it("parses stored dates as local calendar days and rejects impossible ones", () => {
+    expect(parseLocalDate("2026-03-15")).toEqual(new Date(2026, 2, 15));
+    // The stored form carries a time and a zone; only the calendar day matters.
+    expect(parseLocalDate("2026-03-15 10:30:00.000Z")).toEqual(new Date(2026, 2, 15));
+    expect(parseLocalDate("2026-03-15T10:30:00.000Z")).toEqual(new Date(2026, 2, 15));
+
+    // Date would roll these into the following month instead of failing.
+    expect(parseLocalDate("2026-02-31")).toBe(null);
+    expect(parseLocalDate("2026-13-01")).toBe(null);
+    expect(parseLocalDate("2026-00-10")).toBe(null);
+
+    // Anything that is not the stored shape still goes through Date, but is
+    // flattened to local midnight so bounds stay comparable.
+    expect(parseLocalDate("2026-3-15")).toEqual(new Date(2026, 2, 15));
+
+    expect(parseLocalDate("not-a-date")).toBe(null);
+    expect(parseLocalDate("")).toBe(null);
+    expect(parseLocalDate(undefined)).toBe(null);
+    expect(parseLocalDate(null)).toBe(null);
   });
 
   it("converts to the main currency, delegates logo urls, and picks deterministic colors", () => {

--- a/apps/web/src/components/calendar/types.test.ts
+++ b/apps/web/src/components/calendar/types.test.ts
@@ -146,6 +146,106 @@ describe("calendar types helpers", () => {
     ).toEqual([15]);
   });
 
+  it("never projects occurrences before the subscription start date", () => {
+    const cycles = [
+      { id: "monthly", name: "Monthly" as const },
+      { id: "yearly", name: "Yearly" as const },
+      { id: "weekly", name: "Weekly" as const },
+    ];
+
+    const monthly = getSubscription({
+      cycle: "monthly",
+      start_date: "2026-01-01",
+      next_payment: "2026-03-15",
+    });
+
+    // Regression (#19): months before the start date must stay empty.
+    expect(getOccurrencesInMonth(monthly, 2025, 12, cycles)).toEqual([]);
+    expect(getOccurrencesInMonth(monthly, 2025, 6, cycles)).toEqual([]);
+    expect(
+      getOccurrencesInMonth(monthly, 2026, 1, cycles).map((date) =>
+        date.getDate(),
+      ),
+    ).toEqual([15]);
+
+    // Non-monthly cycles honour the start date as well.
+    expect(
+      getOccurrencesInMonth(
+        getSubscription({
+          cycle: "yearly",
+          start_date: "2026-01-01",
+          next_payment: "2026-03-15",
+        }),
+        2025,
+        3,
+        cycles,
+      ),
+    ).toEqual([]);
+
+    // A start date inside the rendered month only hides the earlier occurrences.
+    expect(
+      getOccurrencesInMonth(
+        getSubscription({
+          cycle: "weekly",
+          start_date: "2026-03-10",
+          next_payment: "2026-03-24",
+        }),
+        2026,
+        3,
+        cycles,
+      ).map((date) => date.getDate()),
+    ).toEqual([10, 17, 24, 31]);
+
+    // Subscriptions without a start date keep their previous behaviour.
+    expect(
+      getOccurrencesInMonth(
+        getSubscription({
+          cycle: "monthly",
+          start_date: "",
+          next_payment: "2026-03-15",
+        }),
+        2025,
+        12,
+        cycles,
+      ).map((date) => date.getDate()),
+    ).toEqual([15]);
+  });
+
+  it("stops projecting occurrences after a scheduled cancellation date", () => {
+    const cycles = [{ id: "daily", name: "Daily" as const }];
+
+    const cancelled = getSubscription({
+      cycle: "daily",
+      frequency: 10,
+      start_date: "2026-01-01",
+      next_payment: "2026-03-01",
+      cancellation_date: "2026-03-21",
+    });
+
+    // March would hold the 1st, 11th, 21st and 31st — the 31st is after the end.
+    expect(
+      getOccurrencesInMonth(cancelled, 2026, 3, cycles).map((date) =>
+        date.getDate(),
+      ),
+    ).toEqual([1, 11, 21]);
+
+    // Months entirely after the cancellation date are empty.
+    expect(getOccurrencesInMonth(cancelled, 2026, 4, cycles)).toEqual([]);
+
+    // A cancellation date after the rendered month changes nothing.
+    expect(
+      getOccurrencesInMonth(
+        getSubscription({
+          ...cancelled,
+          cancellation_date: "2027-01-01",
+        }),
+        2026,
+        3,
+        cycles,
+      ).map((date) => date.getDate()),
+    ).toEqual([1, 11, 21, 31]);
+  });
+
   it("returns no occurrences for inactive subscriptions, missing dates, or invalid dates", () => {
     const cycles = [{ id: "monthly", name: "Monthly" as const }];
 
@@ -173,9 +273,18 @@ describe("calendar types helpers", () => {
         cycles,
       ),
     ).toEqual([]);
+    // A single-segment value falls through to new Date(value), which is invalid too
+    expect(
+      getOccurrencesInMonth(
+        getSubscription({ next_payment: "nonsense" }),
+        2026,
+        3,
+        cycles,
+      ),
+    ).toEqual([]);
 
-    // Line 103: datePart has fewer than 3 dash-segments, so the else branch executes.
-    // "2026-03" splits into ["2026","03"] (length 2), triggering cursor = new Date("2026-03")
+    // datePart has fewer than 3 dash-segments, so the else branch executes.
+    // "2026-03" splits into ["2026","03"] (length 2), triggering new Date("2026-03")
     expect(
       getOccurrencesInMonth(
         getSubscription({ next_payment: "2026-03", cycle: "monthly" }),

--- a/apps/web/src/components/calendar/types.ts
+++ b/apps/web/src/components/calendar/types.ts
@@ -59,6 +59,26 @@ export function getPaymentRecord(
   return paid[0] ?? matches[0];
 }
 
+/**
+ * Parses a stored date (date-only or ISO datetime) as a local calendar date so
+ * comparisons stay in the user's timezone instead of drifting through UTC.
+ */
+export function parseLocalDate(value: string | undefined | null): Date | null {
+  if (!value) return null;
+
+  const datePart = value.split(/[T ]/)[0];
+  const parts = datePart.split("-");
+
+  if (parts.length >= 3) {
+    const [y, m, d] = parts.map(Number);
+    const parsed = new Date(y, m - 1, d);
+    return isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const fallback = new Date(value);
+  return isNaN(fallback.getTime()) ? null : fallback;
+}
+
 export function getOccurrencesInMonth(
   sub: Subscription,
   year: number,
@@ -75,17 +95,31 @@ export function getOccurrencesInMonth(
   const monthStart = new Date(year, month - 1, 1);
   const monthEnd = new Date(year, month, 0, 23, 59, 59);
 
-  let cursor: Date;
-  if (!sub.next_payment) return [];
+  const anchor = parseLocalDate(sub.next_payment);
+  if (!anchor) return [];
 
-  const datePart = sub.next_payment.split(/[T ]/)[0];
-  const parts = datePart.split("-");
-  if (parts.length >= 3) {
-    const [py, pm, pd] = parts.map(Number);
-    cursor = new Date(py, pm - 1, pd);
-  } else {
-    cursor = new Date(sub.next_payment);
-  }
+  let cursor = anchor;
+
+  // Occurrences only exist inside the subscription's own lifetime: never before
+  // its start date and never after a scheduled cancellation date.
+  const startDate = parseLocalDate(sub.start_date);
+  const endDate = parseLocalDate(sub.cancellation_date);
+
+  const rangeStart =
+    startDate && startDate > monthStart ? startDate : monthStart;
+  const rangeEnd =
+    endDate && endDate < monthEnd
+      ? new Date(
+          endDate.getFullYear(),
+          endDate.getMonth(),
+          endDate.getDate(),
+          23,
+          59,
+          59,
+        )
+      : monthEnd;
+
+  if (rangeStart > rangeEnd) return [];
 
   // Preserve the intended day-of-month so month arithmetic never overflows.
   // e.g. a subscription on the 30th must land on the 30th (or last day of
@@ -116,10 +150,8 @@ export function getOccurrencesInMonth(
     return new Date(d);
   };
 
-  if (isNaN(cursor.getTime())) return [];
-
   let g = 0;
-  while (cursor > monthStart && g++ < 600) {
+  while (cursor > rangeStart && g++ < 600) {
     const prev = sub1(cursor);
     if (prev.getTime() >= cursor.getTime()) break;
     cursor = prev;
@@ -127,8 +159,8 @@ export function getOccurrencesInMonth(
 
   const results: Date[] = [];
   g = 0;
-  while (cursor <= monthEnd && g++ < 600) {
-    if (cursor >= monthStart) results.push(new Date(cursor));
+  while (cursor <= rangeEnd && g++ < 600) {
+    if (cursor >= rangeStart) results.push(new Date(cursor));
     const next = add(cursor);
     if (next.getTime() <= cursor.getTime()) break;
     cursor = next;

--- a/apps/web/src/components/calendar/types.ts
+++ b/apps/web/src/components/calendar/types.ts
@@ -59,6 +59,8 @@ export function getPaymentRecord(
   return paid[0] ?? matches[0];
 }
 
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 /**
  * Parses a stored date (date-only or ISO datetime) as a local calendar date so
  * comparisons stay in the user's timezone instead of drifting through UTC.
@@ -67,16 +69,31 @@ export function parseLocalDate(value: string | undefined | null): Date | null {
   if (!value) return null;
 
   const datePart = value.split(/[T ]/)[0];
-  const parts = datePart.split("-");
+  const match = DATE_ONLY_PATTERN.exec(datePart);
 
-  if (parts.length >= 3) {
-    const [y, m, d] = parts.map(Number);
-    const parsed = new Date(y, m - 1, d);
-    return isNaN(parsed.getTime()) ? null : parsed;
+  if (match) {
+    const [year, month, day] = [Number(match[1]), Number(match[2]), Number(match[3])];
+    const parsed = new Date(year, month - 1, day);
+
+    // Date silently rolls impossible days into the next month (Feb 31 becomes
+    // Mar 3), which would move a projection bound without anyone noticing, so
+    // only a value that round-trips unchanged is a real date.
+    if (
+      parsed.getFullYear() !== year
+      || parsed.getMonth() !== month - 1
+      || parsed.getDate() !== day
+    ) {
+      return null;
+    }
+
+    return parsed;
   }
 
   const fallback = new Date(value);
-  return isNaN(fallback.getTime()) ? null : fallback;
+  if (isNaN(fallback.getTime())) return null;
+
+  // Every bound is compared as a local calendar day, whatever shape it arrived in.
+  return new Date(fallback.getFullYear(), fallback.getMonth(), fallback.getDate());
 }
 
 export function getOccurrencesInMonth(

--- a/apps/web/src/components/calendar/useCalendarMonthData.test.tsx
+++ b/apps/web/src/components/calendar/useCalendarMonthData.test.tsx
@@ -102,6 +102,30 @@ describe("useCalendarMonthData", () => {
     vi.useRealTimers();
   });
 
+  it("does not show subscriptions in months before their start date", () => {
+    // Regression (#19): a subscription starting on 2026-01-01 must not appear
+    // in December 2025 or any earlier month.
+    const subscription = getSubscription({
+      start_date: "2026-01-01",
+      next_payment: "2026-01-05",
+    });
+
+    const { result } = renderHook(() =>
+      useCalendarMonthData({
+        subscriptions: [subscription],
+        cycles: [{ id: "cycle-monthly", name: "Monthly" }],
+        currencies: [getCurrency({ is_main: true })],
+        year: 2025,
+        month: 12,
+        selectedDay: 5,
+      }),
+    );
+
+    expect(result.current.entriesByDay).toEqual({});
+    expect(result.current.selectedEntries).toEqual([]);
+    expect(result.current.stats).toEqual({ count: 0, total: 0, due: 0 });
+  });
+
   it("falls back to the first currency and returns empty selected data when no day is selected", () => {
     const firstCurrency = getCurrency({ id: "cur-a", is_main: false });
 


### PR DESCRIPTION
Fixes #19.

## Problem

A subscription starting on 2026-01-01 also showed up in December 2025 and in every earlier month of the calendar.

`getOccurrencesInMonth` builds the billing grid by walking **backwards** from `next_payment` until the cursor falls before the rendered month, then walking forward collecting every occurrence in that month. The only bounds were `monthStart` and `monthEnd` — `start_date` was never consulted, so the projection ran indefinitely into the past. `cancellation_date` was ignored on the upper end for the same reason, which is why cancelled subscriptions kept appearing forever.

## Fix

Occurrences are now clamped to the subscription's own lifetime:

- `rangeStart = max(monthStart, start_date)`
- `rangeEnd = min(monthEnd, end of cancellation_date)`
- empty range short-circuits to `[]`

Because the clamp applies to the projection *range* rather than to a day-of-month assumption, it works uniformly for daily, weekly, monthly and yearly cycles with any frequency. Subscriptions without a `start_date` keep the previous behaviour.

Date parsing was extracted into an exported `parseLocalDate` helper so every bound is compared as a local calendar date instead of drifting through UTC.

## Scope

`getOccurrencesInMonth` is the only occurrence-projection code in the frontend — it is used solely by `useCalendarMonthData` → `CalendarPage`. The dashboard and statistics pages use per-cycle monetary normalization (`toMonthly`), not date projection, so nothing else needed adjusting. The backend `routes_calendar.pb.js` only reads `next_payment` forward and has no equivalent bug.

## Tests

- regression for this issue: start 2026-01-01 → December 2025 and June 2025 are empty, January 2026 still shows the 15th
- yearly cycle, and a mid-month start with a weekly cycle
- subscriptions with an empty `start_date` (backwards compatibility)
- a scheduled `cancellation_date` stops the projection, and a far-future one changes nothing
- hook-level regression in `useCalendarMonthData.test.tsx`: empty `entriesByDay`, `selectedEntries` and zeroed stats for a month before the start date

`src/components/calendar/types.ts` is at 100% statements / branches / functions / lines.

## Verification

- `bun run type-check` passes
- `bun run test:front`: 1467/1470 — the 3 failures (`SubDetailDialog` ×1, `FixerTab` ×2) reproduce identically on `main` and are unrelated
- `bun run lint`: 154 problems, the exact same count as `main` — no new findings from this change
