### PR TITLE
fix(api): resolve auth helper inside external API route callbacks

### DIFF
--- a/apps/backend/pb_hooks/routes_api_keys.pb.js
+++ b/apps/backend/pb_hooks/routes_api_keys.pb.js
@@ -1,12 +1,10 @@
 /// <reference path="../pb_data/types.d.ts" />
 
 // NOTE: In PocketBase JSVM (Goja), file-scope helper bindings are not
-// reliably available inside router callbacks. extractApiKey requires
-// authHeaders internally so it is always self-contained at call time.
-function extractApiKey(e) {
-  var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
-  return authHeaders.extractBearerToken(e.request.header.get("Authorization"));
-}
+// reliably available inside router callbacks: handlers run on a pooled
+// runtime that never evaluated this file's top level. Require helpers
+// inside each callback so the runtime can always resolve them at
+// request time.
 
 // ================================================================
 // GET /api/api-keys  — list keys for the authenticated user
@@ -185,7 +183,8 @@ routerAdd("PUT", "/api/api-keys/{id}", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/subscriptions", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     // inline resolveApiKey
     var userId = null;
@@ -248,7 +247,8 @@ routerAdd("GET", "/api/external/subscriptions", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/subscriptions/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -310,7 +310,8 @@ routerAdd("GET", "/api/external/subscriptions/{id}", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/cycles", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -342,7 +343,8 @@ routerAdd("GET", "/api/external/cycles", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/subscriptions", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     // inline resolveApiKey
     var userId = null;
@@ -408,7 +410,8 @@ routerAdd("POST", "/api/external/subscriptions", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/statistics", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     // inline resolveApiKey
     var userId = null;
@@ -477,7 +480,8 @@ routerAdd("GET", "/api/external/statistics", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/categories", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -517,7 +521,8 @@ routerAdd("GET", "/api/external/categories", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/categories", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -554,7 +559,8 @@ routerAdd("POST", "/api/external/categories", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/payment-methods", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -594,7 +600,8 @@ routerAdd("GET", "/api/external/payment-methods", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/payment-methods", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -631,7 +638,8 @@ routerAdd("POST", "/api/external/payment-methods", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/household", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -671,7 +679,8 @@ routerAdd("GET", "/api/external/household", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/household", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -708,7 +717,8 @@ routerAdd("POST", "/api/external/household", function(e) {
 // ================================================================
 routerAdd("GET", "/api/external/currencies", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -750,7 +760,8 @@ routerAdd("GET", "/api/external/currencies", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/currencies", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
 
     var userId = null;
     if (rawKey) {
@@ -791,7 +802,8 @@ routerAdd("POST", "/api/external/currencies", function(e) {
 // ================================================================
 routerAdd("DELETE", "/api/external/subscriptions/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -823,7 +835,8 @@ routerAdd("DELETE", "/api/external/subscriptions/{id}", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/subscriptions/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -873,7 +886,8 @@ routerAdd("PUT", "/api/external/subscriptions/{id}", function(e) {
 // ================================================================
 routerAdd("DELETE", "/api/external/categories/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -905,7 +919,8 @@ routerAdd("DELETE", "/api/external/categories/{id}", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/categories/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -941,7 +956,8 @@ routerAdd("PUT", "/api/external/categories/{id}", function(e) {
 // ================================================================
 routerAdd("DELETE", "/api/external/payment-methods/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -973,7 +989,8 @@ routerAdd("DELETE", "/api/external/payment-methods/{id}", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/payment-methods/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1009,7 +1026,8 @@ routerAdd("PUT", "/api/external/payment-methods/{id}", function(e) {
 // ================================================================
 routerAdd("DELETE", "/api/external/household/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1041,7 +1059,8 @@ routerAdd("DELETE", "/api/external/household/{id}", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/household/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1077,7 +1096,8 @@ routerAdd("PUT", "/api/external/household/{id}", function(e) {
 // ================================================================
 routerAdd("DELETE", "/api/external/currencies/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1109,7 +1129,8 @@ routerAdd("DELETE", "/api/external/currencies/{id}", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/currencies/{id}", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1146,7 +1167,8 @@ routerAdd("PUT", "/api/external/currencies/{id}", function(e) {
 // ================================================================
 routerAdd("PATCH", "/api/external/subscriptions/{id}/status", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1183,7 +1205,8 @@ routerAdd("PATCH", "/api/external/subscriptions/{id}/status", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/subscriptions/{id}/mark-paid", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1229,7 +1252,8 @@ routerAdd("POST", "/api/external/subscriptions/{id}/mark-paid", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/subscriptions/batch", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1276,7 +1300,8 @@ routerAdd("POST", "/api/external/subscriptions/batch", function(e) {
 // ================================================================
 routerAdd("POST", "/api/external/categories/bulk-rename", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);
@@ -1315,7 +1340,8 @@ routerAdd("POST", "/api/external/categories/bulk-rename", function(e) {
 // ================================================================
 routerAdd("PUT", "/api/external/currencies/{id}/main", function(e) {
   try {
-    var rawKey = extractApiKey(e);
+    var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
+    var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
     var userId = null;
     if (rawKey) {
       var kh = $security.sha256(rawKey);

--- a/apps/backend/tests/pb_hooks/routes_api_keys.test.js
+++ b/apps/backend/tests/pb_hooks/routes_api_keys.test.js
@@ -1,0 +1,117 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const HOOKS_DIR = path.join(__dirname, "../../pb_hooks");
+const SOURCE = fs.readFileSync(path.join(HOOKS_DIR, "routes_api_keys.pb.js"), "utf8");
+
+/**
+ * PocketBase runs each router callback on a pooled Goja runtime that never
+ * evaluated the file it was written in, so a handler only ever sees its own
+ * arguments and whatever it require()s itself. These helpers rebuild that
+ * isolation: every handler is extracted from the source and compiled on its
+ * own, with no access to anything declared at file scope.
+ */
+function extractHandlers(source) {
+  const handlers = [];
+  let index = source.indexOf("\nrouterAdd(");
+
+  while (index !== -1) {
+    const open = source.indexOf("(", index);
+    const commas = [];
+    let depth = 0;
+    let cursor = open;
+    let quote = "";
+
+    for (; cursor < source.length; cursor++) {
+      const char = source[cursor];
+
+      if (quote) {
+        if (char === "\\") cursor++;
+        else if (char === quote) quote = "";
+        continue;
+      }
+      if (char === '"' || char === "'") { quote = char; continue; }
+      if (char === "/" && source[cursor + 1] === "/") {
+        cursor = source.indexOf("\n", cursor);
+        continue;
+      }
+      if (char === "/" && source[cursor + 1] === "*") {
+        cursor = source.indexOf("*/", cursor) + 1;
+        continue;
+      }
+      if (char === "(" || char === "[" || char === "{") depth++;
+      if (char === ")" || char === "]" || char === "}") {
+        depth--;
+        if (depth === 0) break;
+      }
+      if (char === "," && depth === 1) commas.push(cursor);
+    }
+
+    handlers.push({
+      method: /routerAdd\(\s*"([^"]+)"\s*,\s*"([^"]+)"/.exec(source.slice(index))[1],
+      route: /routerAdd\(\s*"([^"]+)"\s*,\s*"([^"]+)"/.exec(source.slice(index))[2],
+      source: source.slice(commas[commas.length - 1] + 1, cursor).trim(),
+    });
+
+    index = source.indexOf("\nrouterAdd(", cursor);
+  }
+
+  return handlers;
+}
+
+function compileInIsolation(handler) {
+  // Only the bindings PocketBase itself injects are in scope — nothing else.
+  return new Function(
+    "require",
+    "__hooks",
+    "$app",
+    "$security",
+    "return (" + handler.source + ");",
+  )(require, HOOKS_DIR, undefined, undefined);
+}
+
+function mockEvent() {
+  const responses = [];
+  return {
+    responses,
+    auth: null,
+    request: {
+      header: { get: () => "" },
+      url: { query: () => ({ get: () => "" }) },
+    },
+    requestInfo: () => ({ body: {} }),
+    json: (status, body) => {
+      responses.push({ status, body });
+      return { status, body };
+    },
+  };
+}
+
+const handlers = extractHandlers(SOURCE);
+
+describe("pb_hooks/routes_api_keys.pb.js", () => {
+  it("registers every route the external API documents", () => {
+    expect(handlers).toHaveLength(32);
+    expect(handlers.filter((h) => h.route.startsWith("/api/external/"))).toHaveLength(28);
+  });
+
+  it("declares no file-scope bindings, which a pooled runtime would not have", () => {
+    const fileScopeDeclarations = SOURCE
+      .split("\n")
+      .filter((line) => /^(function|var|const|let)\s/.test(line));
+
+    expect(fileScopeDeclarations).toEqual([]);
+  });
+
+  it.each(handlers.map((handler) => [handler.method + " " + handler.route, handler]))(
+    "%s resolves its helpers without reaching outside the callback",
+    (_name, handler) => {
+      const e = mockEvent();
+
+      // Unauthenticated and unkeyed, so every handler should reject early —
+      // but only after running the header parsing that used to crash.
+      expect(() => compileInIsolation(handler)(e)).not.toThrow();
+      expect(e.responses[0].status).toBe(401);
+    },
+  );
+});


### PR DESCRIPTION
Fixes #22.

## The bug

Every `/api/external/*` route returned `500` with `{"error":"ReferenceError: extractApiKey is not defined"}`, even when the request carried a valid API key with the correct scope. The whole external REST surface documented in `apps/backend/LLMS.md` was unreachable.

## Root cause

PocketBase executes each router callback on a pooled Goja runtime that never evaluated the file the handler was written in, so bindings declared at file scope are not visible at request time.

`routes_api_keys.pb.js` declared `extractApiKey` at the top of the file and called it from all 28 external handlers, so each one crashed on its very first statement — before any key lookup, which is why the scope on the key made no difference.

`routes_subscriptions.pb.js` and `routes_calendar.pb.js` already document and work around this by requiring helpers inside each callback. This applies the same pattern to `routes_api_keys.pb.js` and drops the file-scope declaration entirely, so there is nothing left to regress to.

## The fix

Each of the 28 external handlers now resolves the helper itself:

```js
var authHeaders = require(__hooks + "/lib/pure/auth-headers.js");
var rawKey = authHeaders.extractBearerToken(e.request.header.get("Authorization"));
```

The 4 authenticated `/api/api-keys` management routes were never affected — they gate on `e.auth` and never called the helper.

## Regression test

`apps/backend/tests/pb_hooks/routes_api_keys.test.js` parses the hook source, extracts all 32 registered handlers, and compiles each one in isolation with only the bindings PocketBase itself injects (`require`, `__hooks`, `$app`, `$security`) in scope — reproducing the pooled-runtime behaviour rather than trusting it.

Each handler is then invoked unauthenticated and unkeyed and must reach its `401`, which means the header parsing that used to crash has to run first. The file is also asserted to declare no file-scope bindings at all.

Verified against the previous code: the 28 external handlers throw the exact `ReferenceError` from the report, while the 4 management routes pass — matching the reported symptom precisely.

## Checks

| | result |
|---|---|
| new regression test | 34 passing |
| `test:back` | 131 passed / 7 failed |
| `lint` | 154 problems |

The 7 backend failures and the 154 lint problems are identical to `main`: 6 integration tests need a `pocketbase` binary that is not checked in (`spawn .../apps/backend/pocketbase ENOENT`) and one `date-helpers` quarterly assertion is timezone-dependent. Backend-only change, so the frontend suite is untouched.

## Related, not fixed here

The same defect class is latent in four other hook files, where file-scope bindings are referenced from inside callbacks:

- `routes_auth.pb.js` — `TOTP_LOGIN_CHALLENGE_TTL_MS` and the four `*TotpLoginChallenge` helpers, used by `/api/auth/totp/login-challenge` and `/api/auth/totp/login-verify`
- `routes_logo.pb.js` — `getQueryParam`, used by `/api/logo_search` and `/api/logo_fetch`
- `routes_cron.pb.js` — `normalizeReminderSlots`
- `security.pb.js` — `PROTECTED_COLLECTIONS`, read inside the record-view and record-list hooks

These are untouched here to keep the fix reviewable and scoped to the reported bug, but they deserve a follow-up — the TOTP login path in particular. The isolation harness in the new test file generalises to them.
