### PR TITLE
fix(hooks): stop every remaining callback from reading file scope

### DIFF
--- a/apps/backend/pb_hooks/lib/pure/request-query.js
+++ b/apps/backend/pb_hooks/lib/pure/request-query.js
@@ -1,0 +1,22 @@
+/**
+ * Reads a single query-string parameter off a PocketBase request event.
+ *
+ * PocketBase exposes the query twice and the two are not always both
+ * usable, so the parsed URL is tried first and requestInfo() is used as a
+ * fallback. Either accessor can throw depending on how the request was
+ * built, so both are guarded and a missing parameter simply reads as "".
+ */
+function getQueryParam(e, key) {
+  let value = "";
+  try {
+    value = e.request.url.query().get(key) || "";
+  } catch (_) { }
+  if (!value) {
+    try {
+      value = e.requestInfo().query[key] || "";
+    } catch (_) { }
+  }
+  return String(value || "").trim();
+}
+
+module.exports = { getQueryParam };

--- a/apps/backend/pb_hooks/lib/totp-challenge.js
+++ b/apps/backend/pb_hooks/lib/totp-challenge.js
@@ -1,0 +1,68 @@
+/**
+ * Short-lived TOTP login challenges.
+ *
+ * After a password authenticates but before a session is issued, the server
+ * stores only a hash of a random challenge plus its expiry on the user
+ * record. The plaintext challenge goes to the client and comes back on the
+ * verify call, so a leaked database row cannot be replayed into a session.
+ *
+ * These helpers live in a required module rather than at the top of
+ * routes_auth.pb.js because PocketBase runs each router callback on a pooled
+ * Goja runtime that never evaluated that file's top level.
+ */
+
+const TOTP_LOGIN_CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+function hashTotpLoginChallenge(challenge) {
+  return $security.sha256(String(challenge || ""));
+}
+
+function clearTotpLoginChallenge(user) {
+  user.set("totp_login_challenge_hash", "");
+  user.set("totp_login_challenge_expires", "");
+}
+
+function createTotpLoginChallenge(user) {
+  const challenge = $security.randomString(64);
+  const expiresAt = new Date(Date.now() + TOTP_LOGIN_CHALLENGE_TTL_MS).toISOString();
+
+  user.set("totp_login_challenge_hash", hashTotpLoginChallenge(challenge));
+  user.set("totp_login_challenge_expires", expiresAt);
+  $app.save(user);
+
+  return { challenge, expiresAt };
+}
+
+function findUserByTotpLoginChallenge(challenge) {
+  const normalizedChallenge = String(challenge || "").trim();
+  if (!normalizedChallenge) return null;
+
+  const rows = $app.findRecordsByFilter(
+    "users",
+    "totp_login_challenge_hash = {:hash}",
+    "",
+    1,
+    0,
+    { hash: hashTotpLoginChallenge(normalizedChallenge) },
+  );
+
+  if (!rows || rows.length === 0) return null;
+
+  const user = rows[0];
+  const expiresAt = String(user.get("totp_login_challenge_expires") || "");
+  if (!expiresAt || Date.parse(expiresAt) <= Date.now()) {
+    clearTotpLoginChallenge(user);
+    $app.save(user);
+    return null;
+  }
+
+  return user;
+}
+
+module.exports = {
+  TOTP_LOGIN_CHALLENGE_TTL_MS,
+  hashTotpLoginChallenge,
+  clearTotpLoginChallenge,
+  createTotpLoginChallenge,
+  findUserByTotpLoginChallenge,
+};

--- a/apps/backend/pb_hooks/routes_auth.pb.js
+++ b/apps/backend/pb_hooks/routes_auth.pb.js
@@ -12,8 +12,10 @@
  * - Admin utilities
  *
  * NOTE: In PocketBase JSVM (Goja), file-scope helper bindings are not
- * reliably available inside router callbacks. Require helpers inside
- * each callback so the runtime can always resolve them at request time.
+ * reliably available inside router callbacks: handlers run on a pooled
+ * runtime that never evaluated this file's top level. Require helpers
+ * inside each callback so the runtime can always resolve them at
+ * request time.
  */
 
 // ================================================================
@@ -46,58 +48,6 @@ routerAdd("GET", "/api/auth/is-admin", (e) => {
 
   return e.json(200, { isAdmin: all[0].id === e.auth.id });
 });
-
-// ================================================================
-// TOTP UTILITIES
-// ================================================================
-
-const TOTP_LOGIN_CHALLENGE_TTL_MS = 5 * 60 * 1000;
-
-function hashTotpLoginChallenge(challenge) {
-  return $security.sha256(String(challenge || ""));
-}
-
-function clearTotpLoginChallenge(user) {
-  user.set("totp_login_challenge_hash", "");
-  user.set("totp_login_challenge_expires", "");
-}
-
-function createTotpLoginChallenge(user) {
-  const challenge = $security.randomString(64);
-  const expiresAt = new Date(Date.now() + TOTP_LOGIN_CHALLENGE_TTL_MS).toISOString();
-
-  user.set("totp_login_challenge_hash", hashTotpLoginChallenge(challenge));
-  user.set("totp_login_challenge_expires", expiresAt);
-  $app.save(user);
-
-  return { challenge, expiresAt };
-}
-
-function findUserByTotpLoginChallenge(challenge) {
-  const normalizedChallenge = String(challenge || "").trim();
-  if (!normalizedChallenge) return null;
-
-  const rows = $app.findRecordsByFilter(
-    "users",
-    "totp_login_challenge_hash = {:hash}",
-    "",
-    1,
-    0,
-    { hash: hashTotpLoginChallenge(normalizedChallenge) },
-  );
-
-  if (!rows || rows.length === 0) return null;
-
-  const user = rows[0];
-  const expiresAt = String(user.get("totp_login_challenge_expires") || "");
-  if (!expiresAt || Date.parse(expiresAt) <= Date.now()) {
-    clearTotpLoginChallenge(user);
-    $app.save(user);
-    return null;
-  }
-
-  return user;
-}
 
 // ================================================================
 // ROUTE: TOTP Setup — generate secret + backup codes (not saved yet)
@@ -257,6 +207,7 @@ routerAdd('POST', '/api/auth/totp/regenerate_backup', function (e) {
 // Stores only a short-lived hashed challenge server-side.
 // ================================================================
 routerAdd('POST', '/api/auth/totp/login-challenge', function (e) {
+  var totpChallenge = require(__hooks + "/lib/totp-challenge.js");
   if (!e.auth) return e.json(401, { error: 'Authentication required' });
 
   var user = $app.findRecordById('users', e.auth.id);
@@ -264,8 +215,8 @@ routerAdd('POST', '/api/auth/totp/login-challenge', function (e) {
     return e.json(400, { error: '2FA is not enabled for this account' });
   }
 
-  clearTotpLoginChallenge(user);
-  var issued = createTotpLoginChallenge(user);
+  totpChallenge.clearTotpLoginChallenge(user);
+  var issued = totpChallenge.createTotpLoginChallenge(user);
 
   return e.json(200, {
     challenge: issued.challenge,
@@ -279,6 +230,7 @@ routerAdd('POST', '/api/auth/totp/login-challenge', function (e) {
 // PocketBase auth token only after the second factor succeeds.
 // ================================================================
 routerAdd('POST', '/api/auth/totp/login-verify', function (e) {
+  var totpChallenge = require(__hooks + "/lib/totp-challenge.js");
   var totpLib = require(__hooks + "/lib/totp.js");
   var verifyTOTP = totpLib.verifyTOTP;
   var body = e.requestInfo().body;
@@ -288,12 +240,12 @@ routerAdd('POST', '/api/auth/totp/login-verify', function (e) {
   if (!challenge) return e.json(400, { error: 'challenge is required' });
   if (!code) return e.json(400, { error: 'code is required' });
 
-  var user = findUserByTotpLoginChallenge(challenge);
+  var user = totpChallenge.findUserByTotpLoginChallenge(challenge);
   if (!user) {
     return e.json(401, { error: 'Invalid or expired login challenge' });
   }
   if (!user.get('totp_enabled')) {
-    clearTotpLoginChallenge(user);
+    totpChallenge.clearTotpLoginChallenge(user);
     $app.save(user);
     return e.json(400, { error: '2FA is not enabled for this account' });
   }
@@ -322,7 +274,7 @@ routerAdd('POST', '/api/auth/totp/login-verify', function (e) {
     return e.json(401, { error: 'Invalid verification code' });
   }
 
-  clearTotpLoginChallenge(user);
+  totpChallenge.clearTotpLoginChallenge(user);
   $app.save(user);
 
   return e.json(200, {

--- a/apps/backend/pb_hooks/routes_cron.pb.js
+++ b/apps/backend/pb_hooks/routes_cron.pb.js
@@ -1,46 +1,13 @@
 /// <reference path="../pb_data/types.d.ts" />
 
-function normalizeReminderSlots(raw) {
-  var fallback = [{ days: 3, hour: 8 }];
-  var parsed = raw;
-
-  if (typeof parsed === "string" && parsed) {
-    try {
-      parsed = JSON.parse(parsed);
-    } catch (_) {
-      parsed = raw;
-    }
-  }
-
-  var source = [];
-  if (Array.isArray(parsed)) {
-    source = parsed;
-  } else if (parsed && typeof parsed === "object" && typeof parsed.length === "number") {
-    for (var i = 0; i < parsed.length; i++) {
-      source.push(parsed[i]);
-    }
-  }
-
-  var normalized = [];
-  for (var si = 0; si < source.length; si++) {
-    var slot = source[si] || {};
-    var days = Number(slot.days);
-    var hour = Number(slot.hour);
-
-    if (!isFinite(days) || !isFinite(hour)) {
-      continue;
-    }
-
-    normalized.push({
-      days: Math.trunc(days),
-      hour: Math.trunc(hour),
-    });
-  }
-
-  return normalized.length > 0 ? normalized : fallback;
-}
+// NOTE: In PocketBase JSVM (Goja), file-scope helper bindings are not
+// reliably available inside router callbacks: handlers run on a pooled
+// runtime that never evaluated this file's top level. Require helpers
+// inside each callback so the runtime can always resolve them at
+// request time.
 
 routerAdd("POST", "/api/cron/{job}", function(e) {
+  var reminderSlots = require(__hooks + "/lib/pure/reminder-slots.js");
   if (!e.auth) throw new ForbiddenError("Authentication required");
 
   var allUsers = $app.findRecordsByFilter("users", "1=1", "+created", 1, 0);
@@ -94,7 +61,7 @@ routerAdd("POST", "/api/cron/{job}", function(e) {
 
       var reminders = [{ days: 3, hour: 8 }];
       try {
-        reminders = normalizeReminderSlots(notifConfig.get("reminders"));
+        reminders = reminderSlots.normalizeReminderSlots(notifConfig.get("reminders"));
       } catch (_) {}
 
       var subs = $app.findRecordsByFilter("subscriptions", "user = {:u} && notify = true && inactive = false", "", 0, 0, { u: userId });

--- a/apps/backend/pb_hooks/routes_logo.pb.js
+++ b/apps/backend/pb_hooks/routes_logo.pb.js
@@ -1,27 +1,17 @@
 /// <reference path="../pb_data/types.d.ts" />
 
 // NOTE: In PocketBase JSVM (Goja), file-scope helper bindings are not
-// reliably available inside router callbacks. Require helpers inside
-// each callback so the runtime can always resolve them at request time.
-
-function getQueryParam(e, key) {
-  let value = "";
-  try {
-    value = e.request.url.query().get(key) || "";
-  } catch (_) { }
-  if (!value) {
-    try {
-      value = e.requestInfo().query[key] || "";
-    } catch (_) { }
-  }
-  return String(value || "").trim();
-}
+// reliably available inside router callbacks: handlers run on a pooled
+// runtime that never evaluated this file's top level. Require helpers
+// inside each callback so the runtime can always resolve them at
+// request time.
 
 // ================================================================
 // ROUTE: Logo Search
 // ================================================================
 routerAdd("GET", "/api/logo_search", (e) => {
   const logoUtils = require(__hooks + "/lib/pure/logo-utils.js");
+  const { getQueryParam } = require(__hooks + "/lib/pure/request-query.js");
   try {
     if (!e.auth) {
       return e.json(403, { error: "Authentication required" });
@@ -78,6 +68,7 @@ routerAdd("GET", "/api/logo_search", (e) => {
 });
 
 routerAdd("GET", "/api/logo_fetch", (e) => {
+  const { getQueryParam } = require(__hooks + "/lib/pure/request-query.js");
   try {
     if (!e.auth) {
       return e.json(403, { error: "Authentication required" });

--- a/apps/backend/pb_hooks/security.pb.js
+++ b/apps/backend/pb_hooks/security.pb.js
@@ -6,20 +6,24 @@
  * Ensures that 'api_key' fields in 'ai_settings' and 'fixer_settings'
  * are never leaked in API responses, even though they are visible in the schema
  * to allow updates.
+ *
+ * NOTE: In PocketBase JSVM (Goja), file-scope bindings are not reliably
+ * available inside hook callbacks: they run on a pooled runtime that never
+ * evaluated this file's top level. The collection names are passed as hook
+ * tags instead, so PocketBase only ever invokes these callbacks for the
+ * protected collections and no in-callback guard is needed.
  */
 
 const PROTECTED_COLLECTIONS = ["ai_settings", "fixer_settings"];
 
 onRecordViewRequest((e) => {
-  if (PROTECTED_COLLECTIONS.indexOf(e.collection.name) !== -1) {
-    e.record.set("api_key", "");
-  }
+  e.record.set("api_key", "");
+  e.next();
 }, ...PROTECTED_COLLECTIONS);
 
 onRecordsListRequest((e) => {
-  if (PROTECTED_COLLECTIONS.indexOf(e.collection.name) !== -1) {
-    for (const record of e.records) {
-      record.set("api_key", "");
-    }
+  for (const record of e.records) {
+    record.set("api_key", "");
   }
+  e.next();
 }, ...PROTECTED_COLLECTIONS);

--- a/apps/backend/tests/pb_hooks/helpers/hook-source.js
+++ b/apps/backend/tests/pb_hooks/helpers/hook-source.js
@@ -1,0 +1,122 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const HOOKS_DIR = path.join(__dirname, "../../../pb_hooks");
+
+/**
+ * PocketBase runs every hook callback on a pooled Goja runtime that never
+ * evaluated the file the callback was written in, so a callback only ever
+ * sees its own arguments and whatever it require()s itself. Reaching for a
+ * binding declared at file scope throws a ReferenceError at request time,
+ * long after the code looked fine at startup.
+ *
+ * These helpers read the hook sources as text so that contract can be
+ * checked without a PocketBase binary.
+ */
+
+function hookFiles() {
+  return fs.readdirSync(HOOKS_DIR)
+    .filter((name) => name.endsWith(".pb.js"))
+    .sort()
+    .map((name) => ({
+      name,
+      source: fs.readFileSync(path.join(HOOKS_DIR, name), "utf8"),
+    }));
+}
+
+/** Names bound at the top level of a file — exactly what a callback cannot see. */
+function fileScopeBindings(source) {
+  const names = [];
+  const pattern = /^(?:function|var|const|let)\s+([A-Za-z_$][\w$]*)/;
+
+  for (const line of source.split("\n")) {
+    const match = pattern.exec(line);
+    if (match) names.push(match[1]);
+  }
+
+  return names;
+}
+
+function skipToMatchingBrace(source, openIndex) {
+  let depth = 0;
+  let quote = "";
+
+  for (let i = openIndex; i < source.length; i++) {
+    const char = source[i];
+
+    if (quote) {
+      if (char === "\\") i++;
+      else if (char === quote) quote = "";
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") { quote = char; continue; }
+    if (char === "/" && source[i + 1] === "/") { i = source.indexOf("\n", i); continue; }
+    if (char === "/" && source[i + 1] === "*") { i = source.indexOf("*/", i) + 1; continue; }
+    if (char === "{" || char === "(" || char === "[") depth++;
+    if (char === "}" || char === ")" || char === "]") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Bodies of every function passed to a top-level registration call
+ * (routerAdd, onRecordViewRequest, cronAdd, …). Only block bodies are
+ * emitted, which is every callback this codebase writes.
+ */
+function callbackBodies(source) {
+  const bodies = [];
+  const registration = /^[A-Za-z_$][\w$]*\(/gm;
+  let call;
+
+  while ((call = registration.exec(source)) !== null) {
+    const argsEnd = skipToMatchingBrace(source, call.index + call[0].length - 1);
+    if (argsEnd === -1) continue;
+
+    const args = source.slice(call.index, argsEnd);
+    const starts = /function\b|=>/g;
+    let marker;
+
+    while ((marker = starts.exec(args)) !== null) {
+      const brace = args.indexOf("{", marker.index);
+      if (brace === -1) break;
+
+      const bodyEnd = skipToMatchingBrace(args, brace);
+      if (bodyEnd === -1) break;
+
+      bodies.push({
+        registration: call[0].slice(0, -1),
+        body: args.slice(brace, bodyEnd + 1),
+      });
+      starts.lastIndex = bodyEnd;
+    }
+
+    registration.lastIndex = argsEnd;
+  }
+
+  return bodies;
+}
+
+/** Identifiers actually read as bindings — property accesses and strings do not count. */
+function referencedIdentifiers(body) {
+  const code = body
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/\/\/[^\n]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\.\s*[A-Za-z_$][\w$]*/g, "");
+
+  return new Set(code.match(/[A-Za-z_$][\w$]*/g) || []);
+}
+
+module.exports = {
+  HOOKS_DIR,
+  hookFiles,
+  fileScopeBindings,
+  callbackBodies,
+  referencedIdentifiers,
+  skipToMatchingBrace,
+};

--- a/apps/backend/tests/pb_hooks/hook-callback-scope.test.js
+++ b/apps/backend/tests/pb_hooks/hook-callback-scope.test.js
@@ -1,0 +1,53 @@
+const {
+  hookFiles,
+  fileScopeBindings,
+  callbackBodies,
+  referencedIdentifiers,
+} = require("./helpers/hook-source.js");
+
+/**
+ * Guards the whole pb_hooks directory against the failure that took down
+ * every /api/external/* route: a callback reaching for a helper declared at
+ * file scope, which the pooled runtime executing it has never seen.
+ *
+ * The check is static because the alternative — booting PocketBase — needs a
+ * binary that is not checked in, and because the bug is invisible until a
+ * request actually hits the route in production.
+ */
+const files = hookFiles();
+
+describe("pb_hooks callback scope", () => {
+  it("finds the hook files to check", () => {
+    expect(files.length).toBeGreaterThan(10);
+    expect(files.map((file) => file.name)).toContain("routes_api_keys.pb.js");
+  });
+
+  it.each(files.map((file) => [file.name, file]))(
+    "%s never reads a file-scope binding from inside a callback",
+    (_name, file) => {
+      const bindings = fileScopeBindings(file.source);
+      const leaks = [];
+
+      for (const callback of callbackBodies(file.source)) {
+        const referenced = referencedIdentifiers(callback.body);
+        for (const binding of bindings) {
+          if (referenced.has(binding)) {
+            leaks.push(callback.registration + " reads " + binding);
+          }
+        }
+      }
+
+      expect(leaks).toEqual([]);
+    },
+  );
+
+  it("only allows file-scope bindings that are consumed at registration time", () => {
+    // PROTECTED_COLLECTIONS is spread into the hook tags, which PocketBase
+    // evaluates while loading the file, so it is never read from a callback.
+    const declared = files.flatMap((file) => (
+      fileScopeBindings(file.source).map((name) => file.name + ":" + name)
+    ));
+
+    expect(declared).toEqual(["security.pb.js:PROTECTED_COLLECTIONS"]);
+  });
+});

--- a/apps/backend/tests/pb_hooks/request-query.test.js
+++ b/apps/backend/tests/pb_hooks/request-query.test.js
@@ -1,0 +1,51 @@
+const { getQueryParam } = require("../../pb_hooks/lib/pure/request-query.js");
+
+function event({ query, info } = {}) {
+  return {
+    request: {
+      url: {
+        query: () => {
+          if (query instanceof Error) throw query;
+          return { get: (key) => (query || {})[key] };
+        },
+      },
+    },
+    requestInfo: () => {
+      if (info instanceof Error) throw info;
+      return { query: info || {} };
+    },
+  };
+}
+
+describe("pb_hooks/lib/pure/request-query.js", () => {
+  it("reads the parameter off the parsed url first", () => {
+    expect(getQueryParam(event({ query: { search: "netflix" } }), "search")).toBe("netflix");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(getQueryParam(event({ query: { search: "  spotify  " } }), "search")).toBe("spotify");
+  });
+
+  it("falls back to requestInfo when the url carries no value", () => {
+    const e = event({ query: { search: "" }, info: { search: "hulu" } });
+    expect(getQueryParam(e, "search")).toBe("hulu");
+  });
+
+  it("falls back to requestInfo when reading the url throws", () => {
+    const e = event({ query: new Error("no url"), info: { search: "disney" } });
+    expect(getQueryParam(e, "search")).toBe("disney");
+  });
+
+  it("returns an empty string when both accessors throw", () => {
+    const e = event({ query: new Error("no url"), info: new Error("no request info") });
+    expect(getQueryParam(e, "search")).toBe("");
+  });
+
+  it("returns an empty string for a parameter neither source has", () => {
+    expect(getQueryParam(event(), "search")).toBe("");
+  });
+
+  it("coerces non-string values", () => {
+    expect(getQueryParam(event({ query: { page: 3 } }), "page")).toBe("3");
+  });
+});

--- a/apps/backend/tests/pb_hooks/routes_api_keys.test.js
+++ b/apps/backend/tests/pb_hooks/routes_api_keys.test.js
@@ -1,7 +1,8 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const HOOKS_DIR = path.join(__dirname, "../../pb_hooks");
+const { HOOKS_DIR, fileScopeBindings, skipToMatchingBrace } = require("./helpers/hook-source.js");
+
 const SOURCE = fs.readFileSync(path.join(HOOKS_DIR, "routes_api_keys.pb.js"), "utf8");
 
 /**
@@ -13,47 +14,22 @@ const SOURCE = fs.readFileSync(path.join(HOOKS_DIR, "routes_api_keys.pb.js"), "u
  */
 function extractHandlers(source) {
   const handlers = [];
-  let index = source.indexOf("\nrouterAdd(");
+  const registration = /^routerAdd\(\s*"([^"]+)"\s*,\s*"([^"]+)"/gm;
+  let call;
 
-  while (index !== -1) {
-    const open = source.indexOf("(", index);
-    const commas = [];
-    let depth = 0;
-    let cursor = open;
-    let quote = "";
-
-    for (; cursor < source.length; cursor++) {
-      const char = source[cursor];
-
-      if (quote) {
-        if (char === "\\") cursor++;
-        else if (char === quote) quote = "";
-        continue;
-      }
-      if (char === '"' || char === "'") { quote = char; continue; }
-      if (char === "/" && source[cursor + 1] === "/") {
-        cursor = source.indexOf("\n", cursor);
-        continue;
-      }
-      if (char === "/" && source[cursor + 1] === "*") {
-        cursor = source.indexOf("*/", cursor) + 1;
-        continue;
-      }
-      if (char === "(" || char === "[" || char === "{") depth++;
-      if (char === ")" || char === "]" || char === "}") {
-        depth--;
-        if (depth === 0) break;
-      }
-      if (char === "," && depth === 1) commas.push(cursor);
-    }
+  while ((call = registration.exec(source)) !== null) {
+    const open = source.indexOf("(", call.index);
+    const argsEnd = skipToMatchingBrace(source, open);
+    const args = source.slice(open, argsEnd);
+    const handlerStart = args.search(/function\b|\([^)]*\)\s*=>/);
 
     handlers.push({
-      method: /routerAdd\(\s*"([^"]+)"\s*,\s*"([^"]+)"/.exec(source.slice(index))[1],
-      route: /routerAdd\(\s*"([^"]+)"\s*,\s*"([^"]+)"/.exec(source.slice(index))[2],
-      source: source.slice(commas[commas.length - 1] + 1, cursor).trim(),
+      method: call[1],
+      route: call[2],
+      source: args.slice(handlerStart).trim(),
     });
 
-    index = source.indexOf("\nrouterAdd(", cursor);
+    registration.lastIndex = argsEnd;
   }
 
   return handlers;
@@ -96,11 +72,7 @@ describe("pb_hooks/routes_api_keys.pb.js", () => {
   });
 
   it("declares no file-scope bindings, which a pooled runtime would not have", () => {
-    const fileScopeDeclarations = SOURCE
-      .split("\n")
-      .filter((line) => /^(function|var|const|let)\s/.test(line));
-
-    expect(fileScopeDeclarations).toEqual([]);
+    expect(fileScopeBindings(SOURCE)).toEqual([]);
   });
 
   it.each(handlers.map((handler) => [handler.method + " " + handler.route, handler]))(

--- a/apps/backend/tests/pb_hooks/totp-challenge.test.js
+++ b/apps/backend/tests/pb_hooks/totp-challenge.test.js
@@ -1,0 +1,116 @@
+const challenges = require("../../pb_hooks/lib/totp-challenge.js");
+
+function userRecord(fields = {}) {
+  const values = { ...fields };
+  return {
+    values,
+    get: (key) => values[key],
+    set: (key, value) => { values[key] = value; },
+  };
+}
+
+let saved;
+
+beforeEach(() => {
+  saved = [];
+  globalThis.$security = {
+    sha256: (value) => "sha256:" + value,
+    randomString: (length) => "r".repeat(length),
+  };
+  globalThis.$app = {
+    findRecordsByFilter: vi.fn(() => []),
+    save: (record) => { saved.push(record); },
+  };
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "$security");
+  Reflect.deleteProperty(globalThis, "$app");
+});
+
+describe("pb_hooks/lib/totp-challenge.js", () => {
+  it("hashes a challenge and treats missing input as an empty string", () => {
+    expect(challenges.hashTotpLoginChallenge("abc")).toBe("sha256:abc");
+    expect(challenges.hashTotpLoginChallenge(null)).toBe("sha256:");
+    expect(challenges.hashTotpLoginChallenge(undefined)).toBe("sha256:");
+  });
+
+  it("clears both challenge fields without saving", () => {
+    const user = userRecord({
+      totp_login_challenge_hash: "sha256:old",
+      totp_login_challenge_expires: "2026-01-01T00:00:00.000Z",
+    });
+
+    challenges.clearTotpLoginChallenge(user);
+
+    expect(user.values.totp_login_challenge_hash).toBe("");
+    expect(user.values.totp_login_challenge_expires).toBe("");
+    expect(saved).toEqual([]);
+  });
+
+  it("stores only the hash and hands the plaintext challenge back", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T12:00:00.000Z"));
+
+    const user = userRecord();
+    const issued = challenges.createTotpLoginChallenge(user);
+
+    expect(issued.challenge).toHaveLength(64);
+    expect(issued.expiresAt).toBe("2026-03-01T12:05:00.000Z");
+    expect(user.values.totp_login_challenge_hash).toBe("sha256:" + issued.challenge);
+    expect(saved).toEqual([user]);
+
+    vi.useRealTimers();
+  });
+
+  it("expires challenges after the documented five minutes", () => {
+    expect(challenges.TOTP_LOGIN_CHALLENGE_TTL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("looks a user up by the hash rather than the plaintext challenge", () => {
+    const user = userRecord({
+      totp_login_challenge_expires: new Date(Date.now() + 60_000).toISOString(),
+    });
+    globalThis.$app.findRecordsByFilter = vi.fn(() => [user]);
+
+    expect(challenges.findUserByTotpLoginChallenge("  secret  ")).toBe(user);
+
+    const params = globalThis.$app.findRecordsByFilter.mock.calls[0][5];
+    expect(params).toEqual({ hash: "sha256:secret" });
+  });
+
+  it("rejects an empty challenge without querying", () => {
+    expect(challenges.findUserByTotpLoginChallenge("")).toBeNull();
+    expect(challenges.findUserByTotpLoginChallenge("   ")).toBeNull();
+    expect(challenges.findUserByTotpLoginChallenge(null)).toBeNull();
+    expect(globalThis.$app.findRecordsByFilter).not.toHaveBeenCalled();
+  });
+
+  it("rejects a challenge no user holds", () => {
+    globalThis.$app.findRecordsByFilter = vi.fn(() => []);
+    expect(challenges.findUserByTotpLoginChallenge("nope")).toBeNull();
+
+    globalThis.$app.findRecordsByFilter = vi.fn(() => null);
+    expect(challenges.findUserByTotpLoginChallenge("nope")).toBeNull();
+  });
+
+  it("burns an expired challenge instead of returning the user", () => {
+    const user = userRecord({
+      totp_login_challenge_hash: "sha256:stale",
+      totp_login_challenge_expires: new Date(Date.now() - 1000).toISOString(),
+    });
+    globalThis.$app.findRecordsByFilter = vi.fn(() => [user]);
+
+    expect(challenges.findUserByTotpLoginChallenge("stale")).toBeNull();
+    expect(user.values.totp_login_challenge_hash).toBe("");
+    expect(saved).toEqual([user]);
+  });
+
+  it("burns a challenge whose expiry was never stored", () => {
+    const user = userRecord({ totp_login_challenge_hash: "sha256:orphan" });
+    globalThis.$app.findRecordsByFilter = vi.fn(() => [user]);
+
+    expect(challenges.findUserByTotpLoginChallenge("orphan")).toBeNull();
+    expect(saved).toEqual([user]);
+  });
+});


### PR DESCRIPTION
Follow-up to #27, which fixed this defect for `/api/external/*`. This closes out the rest of `pb_hooks` and adds a check so it cannot come back.

> **Merge order:** stacked on #27 so the new repo-wide check can cover every hook file with no exceptions. Base retargets to `main` automatically once #27 merges.

## The defect

PocketBase runs each hook callback on a pooled Goja runtime that never evaluated the file the callback was written in. Any binding declared at file scope is therefore absent at request time and throws a `ReferenceError` — code that looks fine at startup and dies on the first request.

Four files were still doing it.

### `routes_auth.pb.js` — the serious one

`/api/auth/totp/login-challenge` and `/api/auth/totp/login-verify` both reached for the TOTP challenge helpers declared at the top of the file, so **the second factor could never be issued or verified**. The four helpers move to `lib/totp-challenge.js`, required inside each callback.

### `routes_logo.pb.js`

`getQueryParam` was read by `/api/logo_search` and `/api/logo_fetch`. It moves to `lib/pure/request-query.js`.

### `routes_cron.pb.js`

The callback read `normalizeReminderSlots` from a file-scope copy that had drifted from `lib/pure/reminder-slots.js` — the module `cron_subscriptions.pb.js` already requires correctly, and which is already tested at 100%. The copy is deleted.

### `security.pb.js`

Both masking callbacks re-checked `PROTECTED_COLLECTIONS`. Rather than work around the scope, the check is removed: those names are already passed as hook tags, so PocketBase only ever invokes these callbacks for `ai_settings` and `fixer_settings`. The guard was redundant, not just broken. The remaining file-scope constant is only spread into the registration, which is evaluated at load time and is safe.

## Also in this PR — please look at this one

Both `security.pb.js` callbacks were **missing `e.next()`**, required since PocketBase v0.23 (this repo pins 0.25.9, and `onboarding.pb.js` and `routes_chat_history.pb.js` both call it). Without it the callbacks stopped the request chain for `ai_settings` and `fixer_settings` instead of masking the key and continuing.

This is a behaviour change beyond the scoping fix, so it is called out rather than buried: with it, those collections become readable again *and* the masking that was intended actually starts applying. Worth a second opinion before merge.

## The check

`tests/pb_hooks/hook-callback-scope.test.js` walks every `*.pb.js`, extracts the callbacks passed to each top-level registration, resolves the identifiers they actually read as bindings (property accesses, strings and comments excluded), and fails on any that only exist at file scope.

Verified by reverting the four fixes — it names each one precisely:

```
routes_auth.pb.js   routerAdd reads clearTotpLoginChallenge
                    routerAdd reads createTotpLoginChallenge
                    routerAdd reads findUserByTotpLoginChallenge
routes_cron.pb.js   routerAdd reads normalizeReminderSlots
routes_logo.pb.js   routerAdd reads getQueryParam
security.pb.js      onRecordViewRequest reads PROTECTED_COLLECTIONS
                    onRecordsListRequest reads PROTECTED_COLLECTIONS
```

A companion assertion pins the full list of file-scope bindings in the whole directory to the single registration-time constant, so a new one cannot be added without a deliberate decision.

The isolation harness from #27 moves into `tests/pb_hooks/helpers/hook-source.js` and is shared by both test files.

## Checks

| | result |
|---|---|
| `test:back` | 169 passed / 7 failed |
| `lib/pure/request-query.js` coverage | 100% statements, branches, functions, lines |
| new module + scope tests | 38 passing |
| `lint` | 154 problems |

The 7 backend failures and 154 lint problems are identical to `main`: 6 integration tests need a `pocketbase` binary that is not checked in, and one `date-helpers` quarterly assertion is timezone-dependent.

## What is not covered

`lib/totp-challenge.js` is unit tested against stubbed `$app`/`$security` (12 cases: hashing, expiry burn-off, lookup by hash rather than plaintext), but the TOTP login flow still has no end-to-end coverage, because there is no PocketBase binary in the repo to run it against. The move itself follows the pattern `lib/notifications.js` already proves in production — a required module reached from a callback, using PocketBase globals.
