### PR TITLE
refactor(auth): one owner for the registration policy, lockdown included

### DIFF
--- a/apps/backend/pb_hooks/lib/pure/oidc-core.js
+++ b/apps/backend/pb_hooks/lib/pure/oidc-core.js
@@ -148,23 +148,6 @@ function canClaimExistingAccount(profile) {
 }
 
 /**
- * Signing in through a provider still creates a local account, so the admin's
- * signup policy applies: registrations must be open and the user limit, when
- * one is set, must not be reached yet.
- *
- * `countUsers` is a callback rather than a number so the caller only pays for
- * counting when a limit is actually configured.
- */
-function canProvisionNewAccount(policy, countUsers) {
-  if (!policy || !policy.openRegistrations) return false;
-
-  const max = Number(policy.maxUsers);
-  if (!isFinite(max) || max <= 0) return true;
-
-  return Number(countUsers()) < max;
-}
-
-/**
  * Validates the claims of an ID token that was fetched straight from the token
  * endpoint. OIDC Core 3.1.3.7 lets the TLS connection to that endpoint stand in
  * for signature verification, so what is left to check is that the token was
@@ -260,7 +243,6 @@ module.exports = {
   buildAuthorizationUrl: buildAuthorizationUrl,
   extractOidcProfile: extractOidcProfile,
   canClaimExistingAccount: canClaimExistingAccount,
-  canProvisionNewAccount: canProvisionNewAccount,
   validateIdTokenClaims: validateIdTokenClaims,
   createStateToken: createStateToken,
   verifyStateToken: verifyStateToken,

--- a/apps/backend/pb_hooks/lib/pure/registration-policy.js
+++ b/apps/backend/pb_hooks/lib/pure/registration-policy.js
@@ -7,11 +7,16 @@
  * page through a public endpoint. Keeping the rules here means both callers
  * answer identically.
  *
+ * `disable_login` counts too: an instance in lockdown that still accepted
+ * signups would hand out accounts nobody can log into.
+ *
  * The very first account is always allowed regardless of the settings —
  * otherwise a fresh instance whose defaults happen to be off could never be
- * bootstrapped, locking the owner out of their own deployment.
+ * bootstrapped, locking the owner out of their own deployment. That
+ * anti-lockout guarantee outranks every other rule here, lockdown included.
  */
 
+const LOGINS_DISABLED = "Logins are currently disabled on this instance";
 const REGISTRATIONS_CLOSED = "Registrations are closed on this instance";
 const USER_LIMIT_REACHED = "This instance has reached its user limit";
 
@@ -27,7 +32,9 @@ function isBootstrap(userCount) {
 /** Null when a signup may proceed, otherwise the reason it may not. */
 function registrationRejection(policy, userCount) {
   if (isBootstrap(userCount)) return null;
-  if (!policy || !policy.openRegistrations) return REGISTRATIONS_CLOSED;
+  if (!policy) return REGISTRATIONS_CLOSED;
+  if (policy.disableLogin) return LOGINS_DISABLED;
+  if (!policy.openRegistrations) return REGISTRATIONS_CLOSED;
 
   const max = Number(policy.maxUsers);
   if (!isFinite(max) || max <= 0) return null;
@@ -40,6 +47,7 @@ function isRegistrationOpen(policy, userCount) {
 }
 
 module.exports = {
+  LOGINS_DISABLED,
   REGISTRATIONS_CLOSED,
   USER_LIMIT_REACHED,
   isBootstrap,

--- a/apps/backend/pb_hooks/registration.pb.js
+++ b/apps/backend/pb_hooks/registration.pb.js
@@ -12,6 +12,10 @@
  * page can ask, and a guard on the create request itself so the answer
  * cannot simply be ignored by posting straight to the collection.
  *
+ * The OIDC callback provisions accounts through $app.save(), which no
+ * request hook can see, so it answers to lib/pure/registration-policy.js
+ * directly. Both paths share that module so they can never disagree.
+ *
  * NOTE: In PocketBase JSVM (Goja), file-scope helper bindings are not
  * reliably available inside hook callbacks: they run on a pooled runtime
  * that never evaluated this file's top level. Require helpers inside each
@@ -31,13 +35,14 @@ routerAdd("GET", "/api/auth/registration-status", (e) => {
   e.response.header().set("Pragma", "no-cache");
   e.response.header().set("Expires", "0");
 
-  let settings = { openRegistrations: false, maxUsers: 0 };
+  let settings = { openRegistrations: false, maxUsers: 0, disableLogin: false };
   try {
     const rows = $app.findRecordsByFilter("admin_settings", "", "", 1, 0);
     if (rows.length > 0) {
       settings = {
         openRegistrations: rows[0].getBool("open_registrations"),
         maxUsers: rows[0].getFloat("max_users"),
+        disableLogin: rows[0].getBool("disable_login"),
       };
     }
   } catch (_) {}
@@ -70,13 +75,14 @@ onRecordCreateRequest((e) => {
     if (admins.length > 0 && admins[0].id === e.auth.id) return e.next();
   }
 
-  let settings = { openRegistrations: false, maxUsers: 0 };
+  let settings = { openRegistrations: false, maxUsers: 0, disableLogin: false };
   try {
     const rows = $app.findRecordsByFilter("admin_settings", "", "", 1, 0);
     if (rows.length > 0) {
       settings = {
         openRegistrations: rows[0].getBool("open_registrations"),
         maxUsers: rows[0].getFloat("max_users"),
+        disableLogin: rows[0].getBool("disable_login"),
       };
     }
   } catch (_) {}

--- a/apps/backend/pb_hooks/routes_oidc.pb.js
+++ b/apps/backend/pb_hooks/routes_oidc.pb.js
@@ -94,6 +94,7 @@ routerAdd("GET", "/api/auth/oidc/authorize", (e) => {
 routerAdd("POST", "/api/auth/oidc/callback", (e) => {
   const oidc = require(__hooks + "/lib/pure/oidc-core.js");
   const oidcSettings = require(__hooks + "/lib/oidc-settings.js");
+  const registrationPolicy = require(__hooks + "/lib/pure/registration-policy.js");
 
   const body = e.requestInfo().body;
   const code = String(body.code || "").trim();
@@ -250,11 +251,14 @@ routerAdd("POST", "/api/auth/oidc/callback", (e) => {
   }
 
   if (!user) {
-    // Creating an account here is a self-registration, so it obeys the same
-    // policy the admin set for the signup form.
-    if (!oidc.canProvisionNewAccount(settings, oidcSettings.countUsers)) {
-      return e.json(403, { error: "Registrations are closed on this instance" });
-    }
+    // Creating an account here is a self-registration, so it answers to the
+    // same module the signup form does — the two must never disagree about
+    // who is allowed in.
+    const rejection = registrationPolicy.registrationRejection(
+      settings,
+      oidcSettings.countUsers(),
+    );
+    if (rejection) return e.json(403, { error: rejection });
 
     const col = $app.findCollectionByNameOrId("users");
     user = new Record(col);

--- a/apps/backend/tests/pb_hooks/oidc-core.test.js
+++ b/apps/backend/tests/pb_hooks/oidc-core.test.js
@@ -279,48 +279,6 @@ describe("pb_hooks/lib/pure/oidc-core.js", () => {
     });
   });
 
-  describe("canProvisionNewAccount", () => {
-    const count = (value) => () => value;
-
-    it("refuses to create accounts while registrations are closed", () => {
-      expect(oidc.canProvisionNewAccount({ openRegistrations: false }, count(0))).toBe(false);
-      expect(oidc.canProvisionNewAccount(null, count(0))).toBe(false);
-    });
-
-    it("allows creation when registrations are open and no limit is set", () => {
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true }, count(999))).toBe(true);
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true, maxUsers: 0 }, count(999)))
-        .toBe(true);
-    });
-
-    it("stops creating accounts once max_users is reached", () => {
-      const policy = { openRegistrations: true, maxUsers: 3 };
-
-      expect(oidc.canProvisionNewAccount(policy, count(2))).toBe(true);
-      expect(oidc.canProvisionNewAccount(policy, count(3))).toBe(false);
-      expect(oidc.canProvisionNewAccount(policy, count(4))).toBe(false);
-    });
-
-    it("ignores an unusable limit rather than locking everyone out", () => {
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true, maxUsers: NaN }, count(5)))
-        .toBe(true);
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true, maxUsers: -1 }, count(5)))
-        .toBe(true);
-    });
-
-    it("does not count the users at all unless a limit is configured", () => {
-      const countUsers = vi.fn(() => 0);
-
-      expect(oidc.canProvisionNewAccount({ openRegistrations: false }, countUsers)).toBe(false);
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true }, countUsers)).toBe(true);
-      expect(countUsers).not.toHaveBeenCalled();
-
-      expect(oidc.canProvisionNewAccount({ openRegistrations: true, maxUsers: 2 }, countUsers))
-        .toBe(true);
-      expect(countUsers).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe("validateIdTokenClaims", () => {
     const now = 1_700_000_000_000;
     const validClaims = {

--- a/apps/backend/tests/pb_hooks/registration-policy.test.js
+++ b/apps/backend/tests/pb_hooks/registration-policy.test.js
@@ -1,4 +1,5 @@
 const {
+  LOGINS_DISABLED,
   REGISTRATIONS_CLOSED,
   USER_LIMIT_REACHED,
   isBootstrap,
@@ -67,6 +68,25 @@ describe("pb_hooks/lib/pure/registration-policy.js", () => {
       expect(registrationRejection(limited, 3)).toBe(USER_LIMIT_REACHED);
     });
 
+    it("refuses a signup while the instance is in lockdown", () => {
+      // An account created here could never be logged into, so offering one
+      // would only be confusing.
+      expect(registrationRejection({ openRegistrations: true, disableLogin: true }, 1))
+        .toBe(LOGINS_DISABLED);
+    });
+
+    it("still lets the first account through in lockdown", () => {
+      // The anti-lockout guarantee outranks lockdown, or an instance that
+      // shipped with the toggle on could never be set up at all.
+      expect(registrationRejection({ openRegistrations: false, disableLogin: true }, 0))
+        .toBeNull();
+    });
+
+    it("reports lockdown ahead of a closed signup form", () => {
+      expect(registrationRejection({ openRegistrations: false, disableLogin: true }, 1))
+        .toBe(LOGINS_DISABLED);
+    });
+
     it("checks the closed toggle before the limit", () => {
       const closedButUnderLimit = { openRegistrations: false, maxUsers: 100 };
       expect(registrationRejection(closedButUnderLimit, 1)).toBe(REGISTRATIONS_CLOSED);
@@ -79,6 +99,7 @@ describe("pb_hooks/lib/pure/registration-policy.js", () => {
       expect(isRegistrationOpen(CLOSED, 1)).toBe(false);
       expect(isRegistrationOpen(CLOSED, 0)).toBe(true);
       expect(isRegistrationOpen({ openRegistrations: true, maxUsers: 2 }, 2)).toBe(false);
+      expect(isRegistrationOpen({ openRegistrations: true, disableLogin: true }, 1)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Follow-up on the three notes left on #29.

## 1. Two copies of the same access rule

The OIDC callback and the signup guard each decided independently who was allowed to create an account: `oidc-core.js` carried `canProvisionNewAccount` alongside `lib/pure/registration-policy.js`. They were already subtly different — the OIDC copy had no bootstrap exemption — which is exactly how these drift into disagreeing about who gets in.

**Rather than have `oidc-core` delegate, its copy is deleted outright** and the callback requires `registration-policy.js` directly:

```js
const rejection = registrationPolicy.registrationRejection(settings, oidcSettings.countUsers());
if (rejection) return e.json(403, { error: rejection });
```

Two reasons for deleting over delegating:

- Delegating would mean one pure module `require`-ing another. Whether Goja resolves a relative require from inside an already-required module is not something worth betting an auth path on, and it would only have shown up at request time.
- `oidc-core.js` goes back to being OIDC protocol logic and nothing else. Registration policy was never its concern.

The 403 body now carries the specific reason (closed / limit reached / lockdown) instead of always saying "Registrations are closed".

### Behaviour change worth noting

The OIDC path now inherits the **bootstrap exemption** — with zero users it allows provisioning, where the old copy refused. This is unreachable through the UI (enabling OIDC requires the admin panel, which requires an account), so it aligns the two paths without opening anything real. Flagging it because it is a security path.

## 2. `disable_login` now refuses signups

An instance in lockdown that kept accepting registrations handed out accounts nobody could log into.

Order of checks, highest priority first:

| check | outcome |
|---|---|
| no users yet (bootstrap) | **allow** |
| `disable_login` | refuse — lockdown |
| `open_registrations` off | refuse — closed |
| `max_users` reached | refuse — limit |

The bootstrap exemption deliberately outranks lockdown. A fresh instance that somehow shipped with the toggle on can still be set up rather than being permanently bricked — an anti-lockout guarantee is worth more than a lockdown that only applies before anyone can log in to lift it.

## 3. The third note needed no code

`onRecordCreateRequest` is a request hook and never sees the OIDC path's `$app.save()` — which is precisely why that path calls the policy itself rather than relying on the guard. Now that both reach the same module, they cannot disagree. Written into the `registration.pb.js` header so the next reader does not have to rediscover it.

## Checks

| | result | baseline |
|---|---|---|
| `test:back` | 229 passed / 7 failed | same 7 as `main` |
| `oidc-core.js` coverage | 100% on all four | held after deleting the helper |
| `registration-policy.js` coverage | 100% on all four | — |
| callback-scope check | 24 passing | — |
| `lint` | 154 problems | identical |
| `tsc --noEmit` | clean | — |

Test count moves 231 → 229: five `canProvisionNewAccount` tests removed with the helper, three lockdown cases added. Backend-only, so the frontend suite is untouched.
