### PR TITLE
feat(currencies): support zero-decimal currencies

### DIFF
--- a/apps/web/src/components/calendar/CalendarMonthCard.tsx
+++ b/apps/web/src/components/calendar/CalendarMonthCard.tsx
@@ -191,6 +191,7 @@ export function CalendarMonthCard({
                           return sum + toMain(sub.price, currency);
                         }, 0),
                         mainCurrency.symbol,
+                        { currencyCode: mainCurrency.code },
                       )}
                     </span>
                   ) : null}
@@ -254,7 +255,9 @@ export function CalendarMonthCard({
                           {mainCurrency ? (
                             <span className="ml-auto shrink-0 text-[10px] tabular-nums opacity-70">
                               {credit ? "+" : ""}
-                              {formatPrice(sub.price, mainCurrency.symbol)}
+                              {formatPrice(sub.price, mainCurrency.symbol, {
+                                currencyCode: mainCurrency.code,
+                              })}
                             </span>
                           ) : null}
                         </div>

--- a/apps/web/src/components/calendar/CalendarOverview.tsx
+++ b/apps/web/src/components/calendar/CalendarOverview.tsx
@@ -26,6 +26,7 @@ export function CalendarOverview({
 }: CalendarOverviewProps) {
   const { t } = useTranslation();
   const currencySymbol = mainCurrency?.symbol ?? "$";
+  const priceOptions = { currencyCode: mainCurrency?.code };
 
   return (
     <>
@@ -41,14 +42,14 @@ export function CalendarOverview({
           icon={<TrendingUp className="h-5 w-5" />}
           iconClass="bg-blue-500/20 text-blue-500"
           label={t("total")}
-          value={formatPrice(total, currencySymbol)}
+          value={formatPrice(total, currencySymbol, priceOptions)}
           loading={loading}
         />
         <StatCard
           icon={<Clock className="h-5 w-5" />}
           iconClass="bg-amber-500/20 text-amber-500"
           label={t("due")}
-          value={formatPrice(due, currencySymbol)}
+          value={formatPrice(due, currencySymbol, priceOptions)}
           loading={loading}
         />
       </div>
@@ -58,7 +59,7 @@ export function CalendarOverview({
           <AlertTriangle className="h-4 w-4 shrink-0" />
           <span>
             {t("over_budget_warning")}{" "}
-            <strong>{formatPrice(total - budget, currencySymbol)}</strong>
+            <strong>{formatPrice(total - budget, currencySymbol, priceOptions)}</strong>
           </span>
         </div>
       ) : null}

--- a/apps/web/src/components/calendar/DayPanel.test.tsx
+++ b/apps/web/src/components/calendar/DayPanel.test.tsx
@@ -12,8 +12,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/components/calendar/types", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/components/calendar/types")>();
+  const actual = await importOriginal<typeof import("@/components/calendar/types")>();
   return {
     ...actual,
     getColorForSub: mocks.getColorForSub,
@@ -444,7 +443,9 @@ describe("DayPanel", () => {
     );
 
     // formatPrice is called with "$" (the fallback symbol) because cur is undefined
-    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$");
+    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$", {
+      currencyCode: undefined,
+    });
   });
 
   it("shows paid badge in no-logo div when paymentTracking and isPaid are true", () => {

--- a/apps/web/src/components/calendar/DayPanel.tsx
+++ b/apps/web/src/components/calendar/DayPanel.tsx
@@ -76,7 +76,9 @@ export function DayPanel({
               <p className="text-xs text-muted-foreground mt-0.5">
                 {entries.length} {entries.length === 1 ? t("subscription") : t("subscriptions")} ·{" "}
                 <span className="font-medium text-foreground">
-                  {formatPrice(total, mainCurrency.symbol)}
+                  {formatPrice(total, mainCurrency.symbol, {
+                    currencyCode: mainCurrency.code,
+                  })}
                 </span>
               </p>
             ) : (
@@ -196,11 +198,16 @@ export function DayPanel({
                   <div className="shrink-0 text-right">
                     <p className="font-semibold text-sm">
                       {credit ? "+" : ""}
-                      {formatPrice(sub.price, cur?.symbol ?? "$")}
+                      {formatPrice(sub.price, cur?.symbol ?? "$", {
+                        currencyCode: cur?.code,
+                      })}
                     </p>
                     {cur && mainCurrency && cur.id !== mainCurrency.id && (
                       <p className="text-[11px] text-muted-foreground">
-                        ≈ {formatPrice(toMain(sub.price, cur), mainCurrency.symbol)}
+                        ≈{" "}
+                        {formatPrice(toMain(sub.price, cur), mainCurrency.symbol, {
+                          currencyCode: mainCurrency.code,
+                        })}
                       </p>
                     )}
                     {diffDays === 0 && (

--- a/apps/web/src/components/calendar/MarkAsPaidModal.tsx
+++ b/apps/web/src/components/calendar/MarkAsPaidModal.tsx
@@ -1,29 +1,18 @@
 import { useMutation } from "@tanstack/react-query";
-import {
-  CheckCircle2,
-  Eye,
-  FileText,
-  Upload,
-  X,
-} from "lucide-react";
-import { useRef,useState } from "react";
+import { CheckCircle2, Eye, FileText, Upload, X } from "lucide-react";
+import { useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/lib/toast";
 import { formatPrice } from "@/lib/utils";
 import { paymentRecordsService } from "@/services/paymentRecords";
-import type { PaymentRecord,Subscription } from "@/types";
+import type { PaymentRecord, Subscription } from "@/types";
 
-import { getLogoUrl,toDateOnly, toDateStr } from "./types";
+import { getLogoUrl, toDateOnly, toDateStr } from "./types";
 
 interface MarkAsPaidModalProps {
   sub: Subscription;
@@ -49,9 +38,7 @@ export function MarkAsPaidModal({
   const isViewOnly = !!existingRecord?.paid_at;
 
   const [amount, setAmount] = useState(
-    existingRecord?.amount != null
-      ? String(existingRecord.amount)
-      : String(sub.price),
+    existingRecord?.amount != null ? String(existingRecord.amount) : String(sub.price),
   );
   const [notes, setNotes] = useState(existingRecord?.notes ?? "");
   const [proofFile, setProofFile] = useState<File | null>(null);
@@ -76,16 +63,13 @@ export function MarkAsPaidModal({
       if (!recordId) {
         const candidates = await paymentRecordsService.listForSubscription(sub.id, userId);
 
-        const matched = candidates.find(
-          (r) => toDateOnly(r.due_date) === dueDate,
-        );
+        const matched = candidates.find((r) => toDateOnly(r.due_date) === dueDate);
         recordId = matched?.id;
       }
 
       if (recordId) {
         const saved = await paymentRecordsService.update(recordId, data as Partial<PaymentRecord>);
-        if (!saved?.id)
-          throw new Error("Falha ao atualizar registro de pagamento");
+        if (!saved?.id) throw new Error("Falha ao atualizar registro de pagamento");
         return;
       }
 
@@ -110,11 +94,7 @@ export function MarkAsPaidModal({
           <DialogTitle className="flex items-center gap-4">
             {logo ? (
               <div className="h-12 w-12 shrink-0 rounded-2xl overflow-hidden border bg-background p-1.5">
-                <img
-                  src={logo}
-                  alt=""
-                  className="h-full w-full object-contain"
-                />
+                <img src={logo} alt="" className="h-full w-full object-contain" />
               </div>
             ) : (
               <div className="h-12 w-12 shrink-0 rounded-2xl bg-primary/10 flex items-center justify-center text-base font-bold text-primary">
@@ -124,9 +104,7 @@ export function MarkAsPaidModal({
 
             <div className="min-w-0 flex-1">
               <p className="text-lg font-bold leading-tight truncate">
-                {isViewOnly
-                  ? t("view_payment")
-                  : t("mark_as_paid")}
+                {isViewOnly ? t("view_payment") : t("mark_as_paid")}
               </p>
               <p className="text-sm text-muted-foreground truncate mt-0.5">
                 {sub.name} ·{" "}
@@ -139,7 +117,7 @@ export function MarkAsPaidModal({
             </div>
 
             <Badge variant="outline" className="shrink-0">
-              {formatPrice(sub.price, cur?.symbol ?? "$")}
+              {formatPrice(sub.price, cur?.symbol ?? "$", { currencyCode: cur?.code })}
             </Badge>
           </DialogTitle>
         </DialogHeader>
@@ -196,10 +174,7 @@ export function MarkAsPaidModal({
                   className="flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2.5 text-sm text-primary hover:bg-accent/40 transition-colors"
                 >
                   <FileText className="h-4 w-4 shrink-0" />
-                  <span
-                    className="min-w-0 flex-1 truncate"
-                    title={existingRecord?.proof}
-                  >
+                  <span className="min-w-0 flex-1 truncate" title={existingRecord?.proof}>
                     {existingRecord?.proof}
                   </span>
                   <Eye className="h-4 w-4 shrink-0" />
@@ -242,9 +217,7 @@ export function MarkAsPaidModal({
                     </button>
                   )}
 
-                  <p className="text-xs text-muted-foreground">
-                    {t("proof_hint")}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{t("proof_hint")}</p>
                 </>
               ) : (
                 <p className="text-sm text-muted-foreground rounded-xl border px-3 py-3">
@@ -265,9 +238,7 @@ export function MarkAsPaidModal({
                 className="bg-green-600 hover:bg-green-700 text-white"
               >
                 <CheckCircle2 className="h-4 w-4 mr-2" />
-                {mut.isPending
-                  ? t("saving")
-                  : t("confirm_payment")}
+                {mut.isPending ? t("saving") : t("confirm_payment")}
               </Button>
             )}
           </div>

--- a/apps/web/src/components/calendar/SubDetailDialog.tsx
+++ b/apps/web/src/components/calendar/SubDetailDialog.tsx
@@ -122,11 +122,14 @@ export function SubDetailDialog({
             <div className="text-right shrink-0">
               <p className="text-2xl font-extrabold leading-none">
                 {credit ? "+" : ""}
-                {formatPrice(sub.price, cur?.symbol ?? "$")}
+                {formatPrice(sub.price, cur?.symbol ?? "$", { currencyCode: cur?.code })}
               </p>
               {cur && mainCurrency && cur.id !== mainCurrency.id && (
                 <p className="text-xs text-muted-foreground mt-1">
-                  ≈ {formatPrice(toMain(sub.price, cur), mainCurrency.symbol)}
+                  ≈{" "}
+                  {formatPrice(toMain(sub.price, cur), mainCurrency.symbol, {
+                    currencyCode: mainCurrency.code,
+                  })}
                 </p>
               )}
             </div>
@@ -154,7 +157,9 @@ export function SubDetailDialog({
                       <p className="text-xs text-muted-foreground mt-0.5 truncate">
                         {new Date(paymentRecord.paid_at).toLocaleDateString()}
                         {paymentRecord.amount != null &&
-                          ` · ${formatPrice(paymentRecord.amount, cur?.symbol ?? "$")}`}
+                          ` · ${formatPrice(paymentRecord.amount, cur?.symbol ?? "$", {
+                            currencyCode: cur?.code,
+                          })}`}
                       </p>
                     )}
                   </div>

--- a/apps/web/src/components/statistics/StatisticsBreakdownCard.tsx
+++ b/apps/web/src/components/statistics/StatisticsBreakdownCard.tsx
@@ -5,6 +5,7 @@ import { formatPrice } from "@/lib/utils";
 
 interface StatisticsBreakdownCardProps {
   data: StatisticsPieDatum[];
+  mainCode?: string;
   mainSymbol: string;
   title: string;
   totalMonthly: number;
@@ -12,6 +13,7 @@ interface StatisticsBreakdownCardProps {
 
 export function StatisticsBreakdownCard({
   data,
+  mainCode,
   mainSymbol,
   title,
   totalMonthly,
@@ -35,19 +37,15 @@ export function StatisticsBreakdownCard({
               <div
                 className="h-4 w-4 shrink-0 rounded-full shadow-sm"
                 style={{
-                  backgroundColor:
-                    STATISTICS_COLORS[index % STATISTICS_COLORS.length],
+                  backgroundColor: STATISTICS_COLORS[index % STATISTICS_COLORS.length],
                 }}
               />
               <span className="flex-1 font-medium">{item.name}</span>
               <span className="font-bold tracking-tight">
-                {formatPrice(item.value, mainSymbol)}
+                {formatPrice(item.value, mainSymbol, { currencyCode: mainCode })}
               </span>
               <span className="rounded-lg bg-muted/50 px-2 py-0.5 text-sm font-medium text-muted-foreground">
-                {totalMonthly > 0
-                  ? ((item.value / totalMonthly) * 100).toFixed(1)
-                  : 0}
-                %
+                {totalMonthly > 0 ? ((item.value / totalMonthly) * 100).toFixed(1) : 0}%
               </span>
             </div>
           ))}

--- a/apps/web/src/components/statistics/StatisticsDistributionCard.tsx
+++ b/apps/web/src/components/statistics/StatisticsDistributionCard.tsx
@@ -1,12 +1,5 @@
 import { useTranslation } from "react-i18next";
-import {
-  Cell,
-  Legend,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-} from "recharts";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 import { STATISTICS_COLORS } from "@/components/statistics/constants";
 import type { StatisticsPieDatum } from "@/components/statistics/statistics.types";
@@ -15,12 +8,14 @@ import { formatPrice } from "@/lib/utils";
 
 interface StatisticsDistributionCardProps {
   data: StatisticsPieDatum[];
+  mainCode?: string;
   mainSymbol: string;
   title: string;
 }
 
 export function StatisticsDistributionCard({
   data,
+  mainCode,
   mainSymbol,
   title,
 }: StatisticsDistributionCardProps) {
@@ -44,9 +39,7 @@ export function StatisticsDistributionCard({
                 innerRadius={60}
                 outerRadius={100}
                 paddingAngle={2}
-                label={({ name, percent }) =>
-                  `${name} (${(percent * 100).toFixed(0)}%)`
-                }
+                label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
                 labelLine={false}
               >
                 {data.map((_, index) => (
@@ -67,7 +60,9 @@ export function StatisticsDistributionCard({
                   color: "hsl(var(--foreground))",
                   fontWeight: "bold",
                 }}
-                formatter={(value: number) => formatPrice(value, mainSymbol)}
+                formatter={(value: number) =>
+                  formatPrice(value, mainSymbol, { currencyCode: mainCode })
+                }
               />
               <Legend wrapperStyle={{ paddingTop: "20px" }} />
             </PieChart>

--- a/apps/web/src/components/statistics/StatisticsHistoryCard.tsx
+++ b/apps/web/src/components/statistics/StatisticsHistoryCard.tsx
@@ -1,12 +1,5 @@
 import { useTranslation } from "react-i18next";
-import {
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import type { StatisticsHistoryPoint } from "@/components/statistics/statistics.types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,13 +7,11 @@ import { formatPrice } from "@/lib/utils";
 
 interface StatisticsHistoryCardProps {
   data: StatisticsHistoryPoint[];
+  mainCode?: string;
   mainSymbol: string;
 }
 
-export function StatisticsHistoryCard({
-  data,
-  mainSymbol,
-}: StatisticsHistoryCardProps) {
+export function StatisticsHistoryCard({ data, mainCode, mainSymbol }: StatisticsHistoryCardProps) {
   const { t } = useTranslation();
 
   return (
@@ -55,7 +46,10 @@ export function StatisticsHistoryCard({
                   color: "hsl(var(--foreground))",
                   fontWeight: "bold",
                 }}
-                formatter={(value: number) => [formatPrice(value, mainSymbol), "Cost"]}
+                formatter={(value: number) => [
+                  formatPrice(value, mainSymbol, { currencyCode: mainCode }),
+                  "Cost",
+                ]}
               />
               <Line
                 type="monotone"

--- a/apps/web/src/components/statistics/StatisticsSummaryCards.test.tsx
+++ b/apps/web/src/components/statistics/StatisticsSummaryCards.test.tsx
@@ -26,4 +26,19 @@ describe("StatisticsSummaryCards", () => {
     expect(screen.getByText("subscriptions")).toBeInTheDocument();
     expect(screen.getByText("6")).toBeInTheDocument();
   });
+
+  it("renders main-currency totals without decimals for JPY", () => {
+    render(
+      <StatisticsSummaryCards
+        mainCode="JPY"
+        mainSymbol="¥"
+        subscriptionsCount={2}
+        totalMonthly={1000}
+        totalYearly={12000}
+      />,
+    );
+
+    expect(screen.getByText("1,000 ¥")).toBeInTheDocument();
+    expect(screen.getByText("12,000 ¥")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/statistics/StatisticsSummaryCards.tsx
+++ b/apps/web/src/components/statistics/StatisticsSummaryCards.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { formatPrice } from "@/lib/utils";
 
 interface StatisticsSummaryCardsProps {
+  mainCode?: string;
   mainSymbol: string;
   subscriptionsCount: number;
   totalMonthly: number;
@@ -11,6 +12,7 @@ interface StatisticsSummaryCardsProps {
 }
 
 export function StatisticsSummaryCards({
+  mainCode,
   mainSymbol,
   subscriptionsCount,
   totalMonthly,
@@ -23,11 +25,9 @@ export function StatisticsSummaryCards({
       <Card className="group relative overflow-hidden rounded-3xl border bg-card/40 shadow-sm backdrop-blur-md">
         <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
         <CardContent className="relative p-6">
-          <p className="text-sm font-medium text-muted-foreground">
-            {t("total_monthly")}
-          </p>
+          <p className="text-sm font-medium text-muted-foreground">{t("total_monthly")}</p>
           <p className="mt-2 text-3xl font-extrabold tracking-tight">
-            {formatPrice(totalMonthly, mainSymbol)}
+            {formatPrice(totalMonthly, mainSymbol, { currencyCode: mainCode })}
           </p>
         </CardContent>
       </Card>
@@ -35,11 +35,9 @@ export function StatisticsSummaryCards({
       <Card className="group relative overflow-hidden rounded-3xl border bg-card/40 shadow-sm backdrop-blur-md">
         <div className="absolute inset-0 bg-gradient-to-br from-green-500/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
         <CardContent className="relative p-6">
-          <p className="text-sm font-medium text-muted-foreground">
-            {t("total_yearly")}
-          </p>
+          <p className="text-sm font-medium text-muted-foreground">{t("total_yearly")}</p>
           <p className="mt-2 text-3xl font-extrabold tracking-tight">
-            {formatPrice(totalYearly, mainSymbol)}
+            {formatPrice(totalYearly, mainSymbol, { currencyCode: mainCode })}
           </p>
         </CardContent>
       </Card>
@@ -47,12 +45,8 @@ export function StatisticsSummaryCards({
       <Card className="group relative overflow-hidden rounded-3xl border bg-card/40 shadow-sm backdrop-blur-md">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
         <CardContent className="relative p-6">
-          <p className="text-sm font-medium text-muted-foreground">
-            {t("subscriptions")}
-          </p>
-          <p className="mt-2 text-3xl font-extrabold tracking-tight">
-            {subscriptionsCount}
-          </p>
+          <p className="text-sm font-medium text-muted-foreground">{t("subscriptions")}</p>
+          <p className="mt-2 text-3xl font-extrabold tracking-tight">{subscriptionsCount}</p>
         </CardContent>
       </Card>
     </div>

--- a/apps/web/src/components/statistics/useStatisticsDerivedData.test.tsx
+++ b/apps/web/src/components/statistics/useStatisticsDerivedData.test.tsx
@@ -105,6 +105,7 @@ describe("useStatisticsDerivedData", () => {
       },
     );
 
+    expect(result.current.mainCode).toBe("USD");
     expect(result.current.mainSymbol).toBe("$");
     expect(result.current.totalMonthly).toBeCloseTo(50, 5);
     expect(result.current.totalYearly).toBeCloseTo(600, 5);
@@ -188,6 +189,7 @@ describe("useStatisticsDerivedData", () => {
     );
 
     // No main currency → mainSymbol defaults to "$"
+    expect(result.current.mainCode).toBeUndefined();
     expect(result.current.mainSymbol).toBe("$");
     // mainRate defaults to 1 — price is unchanged
     expect(result.current.totalMonthly).toBeCloseTo(10, 5);

--- a/apps/web/src/components/statistics/useStatisticsDerivedData.ts
+++ b/apps/web/src/components/statistics/useStatisticsDerivedData.ts
@@ -26,6 +26,7 @@ export function useStatisticsDerivedData({
     const mainCurrency = currencies.find((currency) => currency.is_main);
     const mainRate = mainCurrency?.rate ?? 1;
     const mainSymbol = mainCurrency?.symbol ?? "$";
+    const mainCode = mainCurrency?.code;
 
     const groupedData = subscriptions
       .filter(isExpense)
@@ -65,6 +66,7 @@ export function useStatisticsDerivedData({
 
     return {
       lineData,
+      mainCode,
       mainSymbol,
       pieData,
       totalMonthly,

--- a/apps/web/src/components/subscriptions/SubscriptionCard.test.tsx
+++ b/apps/web/src/components/subscriptions/SubscriptionCard.test.tsx
@@ -270,7 +270,9 @@ describe("SubscriptionCard", () => {
     // toMonthly should NOT have been called
     expect(mocks.toMonthly).not.toHaveBeenCalled();
     // formatPrice called with raw price 99
-    expect(mocks.formatPrice).toHaveBeenCalledWith(99, expect.any(String));
+    expect(mocks.formatPrice).toHaveBeenCalledWith(99, expect.any(String), {
+      currencyCode: "USD",
+    });
   });
 
   it("keeps one-time credits visible and distinct without recurring actions", () => {
@@ -386,7 +388,9 @@ describe("SubscriptionCard", () => {
       />,
     );
     expect(mocks.toMonthly).toHaveBeenCalledWith(20, "Monthly", 1);
-    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$");
+    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$", {
+      currencyCode: undefined,
+    });
   });
 
   it("falls back to $ symbol when mainCurrency has no symbol and shouldConvert is true", () => {
@@ -402,7 +406,9 @@ describe("SubscriptionCard", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$");
+    expect(mocks.formatPrice).toHaveBeenCalledWith(expect.any(Number), "$", {
+      currencyCode: "USD",
+    });
   });
 
   it("uses empty string src when logoUrl returns null", () => {

--- a/apps/web/src/components/subscriptions/SubscriptionCard.tsx
+++ b/apps/web/src/components/subscriptions/SubscriptionCard.tsx
@@ -136,7 +136,8 @@ export function SubscriptionCard({
   const rawPrice =
     showMonthly && !credit ? toMonthly(sub.price, cycleName, sub.frequency || 1) : sub.price;
   const price = shouldConvert ? toMainCurrency(rawPrice, currency) : rawPrice;
-  const symbol = shouldConvert ? (mainCurrency?.symbol ?? "$") : (currency?.symbol ?? "$");
+  const displayCurrency = shouldConvert ? mainCurrency : currency;
+  const symbol = displayCurrency?.symbol ?? "$";
   const days = daysUntil(sub.next_payment);
   const progress = showProgress ? subscriptionProgress(sub.start_date, sub.next_payment) : 0;
 
@@ -194,7 +195,7 @@ export function SubscriptionCard({
             )}
           >
             {credit ? "+" : ""}
-            {formatPrice(price, symbol)}
+            {formatPrice(price, symbol, { currencyCode: displayCurrency?.code })}
           </p>
           <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">
             {credit ? t("one_time") : showMonthly ? t("monthly") : cycleName}

--- a/apps/web/src/components/ui/currency-input.test.tsx
+++ b/apps/web/src/components/ui/currency-input.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
 
 import { CurrencyInput } from "./currency-input";
 
@@ -42,15 +42,23 @@ describe("CurrencyInput", () => {
     expect(screen.getByText("USD")).toBeInTheDocument();
   });
 
+  it.each(["JPY", "KRW"])("shows no decimals for %s when blurred", (code) => {
+    render(<CurrencyInput value={1000} onChange={() => {}} code={code} />);
+    expect(screen.getByRole("textbox").getAttribute("value")).toMatch(/^1[,.\s]?000$/);
+  });
+
+  it("uses a zero-decimal placeholder for zero-decimal currencies", () => {
+    render(<CurrencyInput value={0} onChange={() => {}} code="JPY" />);
+    expect(screen.getByPlaceholderText("0")).toBeInTheDocument();
+  });
+
   it("renders without symbol or code when they are absent", () => {
     const { container } = render(<CurrencyInput value={0} onChange={() => {}} />);
     expect(container.querySelectorAll("span")).toHaveLength(0);
   });
 
   it("applies disabled styling when the disabled prop is set", () => {
-    const { container } = render(
-      <CurrencyInput value={0} onChange={() => {}} disabled />,
-    );
+    const { container } = render(<CurrencyInput value={0} onChange={() => {}} disabled />);
     expect(container.firstChild).toHaveClass("opacity-50");
   });
 
@@ -160,9 +168,7 @@ describe("CurrencyInput", () => {
   });
 
   it("renders the placeholder when provided", () => {
-    render(
-      <CurrencyInput value={0} onChange={() => {}} placeholder="0.00" />,
-    );
+    render(<CurrencyInput value={0} onChange={() => {}} placeholder="0.00" />);
     expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/ui/currency-input.tsx
+++ b/apps/web/src/components/ui/currency-input.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef,useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { cn } from "@/lib/utils";
+import { cn, getCurrencyFractionDigits } from "@/lib/utils";
 
 interface CurrencyInputProps {
   value: number | string;
@@ -12,12 +12,13 @@ interface CurrencyInputProps {
   disabled?: boolean;
 }
 
-function formatNumber(val: number): string {
+function formatNumber(val: number, code?: string): string {
   /* v8 ignore next -- formatNumber is only called when numeric > 0; NaN > 0 is false so isNaN branch is unreachable */
   if (isNaN(val) || val === 0) return "";
+  const fractionDigits = getCurrencyFractionDigits(code);
   return new Intl.NumberFormat(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(val);
 }
 
@@ -37,7 +38,7 @@ export function CurrencyInput({
   onChange,
   symbol,
   code,
-  placeholder = "0,00",
+  placeholder,
   className,
   disabled,
 }: CurrencyInputProps) {
@@ -74,7 +75,9 @@ export function CurrencyInput({
     onChange(parsed);
   };
 
-  const displayValue = focused ? raw : (numeric > 0 ? formatNumber(numeric) : "");
+  const fractionDigits = getCurrencyFractionDigits(code);
+  const displayValue = focused ? raw : numeric > 0 ? formatNumber(numeric, code) : "";
+  const resolvedPlaceholder = placeholder ?? (fractionDigits === 0 ? "0" : "0,00");
 
   return (
     <div
@@ -82,7 +85,7 @@ export function CurrencyInput({
         "flex items-center h-10 rounded-xl border bg-muted/50 transition-colors",
         "focus-within:bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-0",
         disabled && "opacity-50 pointer-events-none",
-        className
+        className,
       )}
     >
       {symbol && (
@@ -98,7 +101,7 @@ export function CurrencyInput({
         onChange={handleChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        placeholder={placeholder}
+        placeholder={resolvedPlaceholder}
         disabled={disabled}
         className="flex-1 min-w-0 bg-transparent px-2 py-2 text-sm font-semibold outline-none placeholder:text-muted-foreground/50"
       />

--- a/apps/web/src/hooks/useSummaryData.test.tsx
+++ b/apps/web/src/hooks/useSummaryData.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 
-import type { Currency, Subscription } from "@/types";
 import { createQueryClientWrapper } from "@/test/query-client";
+import type { Currency, Subscription } from "@/types";
 
 const { listActive, listCurrencies } = vi.hoisted(() => ({
   listActive: vi.fn(),
@@ -114,6 +114,7 @@ describe("useSummaryData", () => {
     expect(listActive).toHaveBeenCalledWith("user-1");
     expect(listCurrencies).toHaveBeenCalledWith("user-1");
     expect(result.current.data).toMatchObject({
+      mainCode: "BRL",
       mainSymbol: "R$",
       count: 2,
     });

--- a/apps/web/src/hooks/useSummaryData.ts
+++ b/apps/web/src/hooks/useSummaryData.ts
@@ -24,6 +24,7 @@ export function useSummaryData(userId: string) {
       const mainCurrency = currencies.find((c) => c.is_main);
       const mainRate = mainCurrency?.rate ?? 1;
       const mainSymbol = mainCurrency?.symbol ?? "$";
+      const mainCode = mainCurrency?.code;
 
       let totalMonthly = 0;
       let totalCredits = 0;
@@ -72,6 +73,7 @@ export function useSummaryData(userId: string) {
         totalDaily: (totalMonthly * 12) / 365,
         totalCredits,
         mainSymbol,
+        mainCode,
         // Credits are income, not subscriptions: counting them here would
         // disagree with every total on the same card, which excludes them.
         count: expenseCount,

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -13,6 +13,7 @@ import {
   formatDate,
   formatPrice,
   getColorForSub,
+  getCurrencyFractionDigits,
   sanitizeHref,
   subscriptionProgress,
   toMainCurrency,
@@ -90,6 +91,17 @@ describe("formatPrice", () => {
     expect(formatPrice(10, "€")).toBe("10.00 €");
   });
 
+  it.each([
+    ["JPY", "¥"],
+    ["KRW", "₩"],
+  ])("omits decimals for zero-decimal currency %s", (currencyCode, symbol) => {
+    expect(formatPrice(1000, symbol, { currencyCode })).toBe(`1,000 ${symbol}`);
+  });
+
+  it("uses the ISO precision for currencies with three decimals", () => {
+    expect(formatPrice(1, "د.ب", { currencyCode: "BHD" })).toBe("1.000 د.ب");
+  });
+
   it("respects custom locale (pt-BR uses comma separator)", () => {
     const result = formatPrice(1000, "R$", "pt-BR");
     // pt-BR uses period as thousands separator and comma as decimal
@@ -101,6 +113,11 @@ describe("formatPrice", () => {
     // Invalid locale should not throw — fallback uses toFixed(2)
     const result = formatPrice(5.5, "X", "invalid-locale-xyz");
     expect(result).toContain("X");
+  });
+
+  it("falls back to two decimals for a missing or invalid currency code", () => {
+    expect(getCurrencyFractionDigits()).toBe(2);
+    expect(getCurrencyFractionDigits("not-a-currency")).toBe(2);
   });
 });
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,8 +1,8 @@
-import { type ClassValue,clsx } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 import { subscriptionsService } from "@/services/subscriptions";
-import type { Currency,Subscription } from "@/types";
+import type { Currency, Subscription } from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -39,36 +39,55 @@ export function getColorForSub(sub: Subscription, index: number): string {
   return EVENT_COLORS[(hash + index) % EVENT_COLORS.length];
 }
 
-/**
- * Format a price with a currency symbol.
- */
+interface PriceFormatOptions {
+  currencyCode?: string;
+  locale?: string;
+}
+
+/** Return the number of fraction digits defined for an ISO 4217 currency. */
+export function getCurrencyFractionDigits(currencyCode?: string): number {
+  if (!currencyCode) return 2;
+
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currencyCode.toUpperCase(),
+    }).resolvedOptions().maximumFractionDigits ?? 2;
+  } catch {
+    return 2;
+  }
+}
+
+/** Format a price with a currency symbol and the currency's natural precision. */
 export function formatPrice(
   price: number,
   symbol: string,
-  locale = "en-US",
+  options: PriceFormatOptions | string = {},
 ): string {
+  // Keep accepting a locale string for backwards compatibility.
+  const locale = typeof options === "string" ? options : (options.locale ?? "en-US");
+  const fractionDigits = getCurrencyFractionDigits(
+    typeof options === "string" ? undefined : options.currencyCode,
+  );
+
   try {
     return (
       new Intl.NumberFormat(locale, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
       }).format(price) +
       " " +
       symbol
     );
   } catch {
-    return price.toFixed(2) + " " + symbol;
+    return price.toFixed(fractionDigits) + " " + symbol;
   }
 }
 
 /**
  * Convert a price to monthly based on cycle name and frequency.
  */
-export function toMonthly(
-  price: number,
-  cycleName: string,
-  frequency: number,
-): number {
+export function toMonthly(price: number, cycleName: string, frequency: number): number {
   const f = frequency || 1;
   switch (cycleName) {
     case "Daily":
@@ -137,18 +156,13 @@ export function daysUntil(dateStr: string): number {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const target = parseLocalDate(dateStr);
-  return Math.ceil(
-    (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
-  );
+  return Math.ceil((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
 }
 
 /**
  * Progress percentage between start date and next payment.
  */
-export function subscriptionProgress(
-  startDate: string,
-  nextPayment: string,
-): number {
+export function subscriptionProgress(startDate: string, nextPayment: string): number {
   if (!startDate || !nextPayment) return 0;
   const start = parseLocalDate(startDate).getTime();
   const end = parseLocalDate(nextPayment).getTime();

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -69,7 +69,10 @@ export function DashboardPage() {
   });
 
   const summaryData = summary.data;
-  const formatValue = (value: number) => formatPrice(value, summaryData?.mainSymbol ?? "$");
+  const formatValue = (value: number) =>
+    formatPrice(value, summaryData?.mainSymbol ?? "$", {
+      currencyCode: summaryData?.mainCode,
+    });
 
   const { budget, budgetUsed, chartData, isOverBudget, remaining, totalCredits } =
     useDashboardDerivedData({

--- a/apps/web/src/pages/StatisticsPage.tsx
+++ b/apps/web/src/pages/StatisticsPage.tsx
@@ -39,7 +39,7 @@ export function StatisticsPage() {
     enabled: !!userId,
   });
 
-  const { lineData, mainSymbol, pieData, totalMonthly, totalYearly } =
+  const { lineData, mainCode, mainSymbol, pieData, totalMonthly, totalYearly } =
     useStatisticsDerivedData({
       subscriptions: subs,
       currencies,
@@ -53,22 +53,15 @@ export function StatisticsPage() {
     member: t("cost_by_member"),
   };
   const breakdownTitle = t(
-    groupBy === "category"
-      ? "categories"
-      : groupBy === "payment"
-        ? "payment_methods"
-        : "household",
+    groupBy === "category" ? "categories" : groupBy === "payment" ? "payment_methods" : "household",
   );
 
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
-      <StatisticsHeader
-        groupBy={groupBy}
-        groupLabels={groupLabels}
-        onGroupByChange={setGroupBy}
-      />
+      <StatisticsHeader groupBy={groupBy} groupLabels={groupLabels} onGroupByChange={setGroupBy} />
 
       <StatisticsSummaryCards
+        mainCode={mainCode}
         mainSymbol={mainSymbol}
         subscriptionsCount={subs.length}
         totalMonthly={totalMonthly}
@@ -78,14 +71,16 @@ export function StatisticsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <StatisticsDistributionCard
           data={pieData}
+          mainCode={mainCode}
           mainSymbol={mainSymbol}
           title={groupLabels[groupBy]}
         />
-        <StatisticsHistoryCard data={lineData} mainSymbol={mainSymbol} />
+        <StatisticsHistoryCard data={lineData} mainCode={mainCode} mainSymbol={mainSymbol} />
       </div>
 
       <StatisticsBreakdownCard
         data={pieData}
+        mainCode={mainCode}
         mainSymbol={mainSymbol}
         title={breakdownTitle}
         totalMonthly={totalMonthly}


### PR DESCRIPTION
Fixes #21.

Zublo formatted every monetary value with exactly two decimal places. That works for USD, EUR, BRL, and similar currencies, but produces unnatural values such as `1,000.00 ¥` and `1,000.00 ₩` for currencies whose ISO definition has no minor unit.

## Formatting model

Price formatting now derives the natural precision from the selected ISO 4217 currency code through `Intl.NumberFormat`:

- JPY and KRW render with 0 decimal places
- USD, EUR, and BRL continue to render with 2 decimal places
- currencies with a different precision, such as BHD, render with 3 decimal places

The existing symbol placement and locale-aware separators are preserved. Missing or invalid currency codes fall back to two decimal places, so legacy data and custom currencies keep the previous behaviour.

This uses the automatic option requested in the issue rather than adding another account setting. Selecting the currency is enough to get the correct display precision.

## UI coverage

The ISO code now travels alongside the symbol through every monetary display path:

- dashboard totals, remaining budget, credits, and budget overview
- subscription cards, monthly conversions, and main-currency conversions
- calendar overview, daily totals, month cells, details, and payment records
- statistics summaries, breakdowns, distributions, and chart tooltips
- subscription price and profile budget inputs

Currency inputs also use the natural precision while blurred and show `0` instead of `0,00` as the placeholder for zero-decimal currencies. Focused editing and the underlying numeric values remain unchanged.

## Compatibility

No schema migration or data rewrite is required. Calculations and stored prices are unchanged; only presentation precision follows the currency code. The existing locale-string form of `formatPrice` remains supported.

## Tests

Regression coverage includes:

- JPY and KRW zero-decimal formatting
- BHD three-decimal formatting
- the two-decimal fallback for missing or invalid codes
- zero-decimal currency input values and placeholders
- propagation of the main currency code through dashboard and statistics data
- a rendered statistics card using JPY totals

## Checks

| check | result |
|---|---|
| frontend suite | **1,524 passed / 0 failed** across 183 files |
| focused currency and display tests | **137 passed / 0 failed** |
| production build | passed |
| changed production-file lint | passed |
| diff check | passed |

Global frontend lint still reports 140 errors and 13 warnings outside this change. The production files changed here are clean.
