### PR TITLE
fix: dialog outside-click + mobile nav overlap, document reverse proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ Important:
 - set `PB_ENCRYPTION_KEY` in real deployments
 - the first registered user becomes the initial admin
 
+### Running Behind A Reverse Proxy
+
+Zublo is a single PocketBase process, so any proxy that forwards plain HTTP to `9597` without buffering or rewriting the request body works. A minimal Caddy example:
+
+```
+zublo.example.com {
+    reverse_proxy localhost:9597
+}
+```
+
+If you enable MFA or update your profile and get unexpected `400` responses, the most common cause is a proxy directive that buffers, compresses, or rewrites the request body (large `client_max_body_size`/`request_body` tweaks, aggressive compression, or a `Content-Length`/chunked mismatch). Keep the proxy config as close to a plain passthrough as possible; there's no proxy-specific handling required on the Zublo side.
+
 ## Local Development
 
 If you want to work on the repo itself:

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -261,14 +261,19 @@ export function Layout() {
         </header>
 
         {/* Page content */}
-        <main className="flex-1 overflow-y-auto w-full max-w-[1600px] mx-auto p-4 md:p-8 lg:p-10 scroll-smooth">
+        <main
+          className={cn(
+            "flex-1 overflow-y-auto w-full max-w-[1600px] mx-auto p-4 md:p-8 lg:p-10 scroll-smooth",
+            user?.mobile_navigation && "pb-24 md:pb-24",
+          )}
+        >
           <Outlet />
         </main>
       </div>
 
       {/* Mobile bottom nav (when mobile_navigation enabled) */}
       {user?.mobile_navigation && (
-        <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-border/40 bg-card/80 backdrop-blur-xl pb-safe lg:hidden">
+        <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-border/40 bg-card/80 backdrop-blur-xl pb-[env(safe-area-inset-bottom)] lg:hidden">
           {navItems.slice(0, 5).map(({ key, path, icon: Icon }) => {
             const isActive = pathname.startsWith(path);
             return (

--- a/apps/web/src/components/SubscriptionFormModal.tsx
+++ b/apps/web/src/components/SubscriptionFormModal.tsx
@@ -165,7 +165,10 @@ export function SubscriptionFormModal({
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-2xl max-h-[90vh] overflow-y-auto"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{sub ? t("edit_subscription") : t("add_subscription")}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- `SubscriptionFormModal`: clicking outside the add/edit subscription dialog no longer closes it and discards the form (fixes #7)
- `Layout`: main content gets bottom padding when the mobile bottom nav is enabled so the last item in a scrollable list (e.g. calendar day bills) isn't hidden behind the fixed nav; also fixed the nav's `pb-safe` class, which wasn't defined anywhere, to use `env(safe-area-inset-bottom)` directly (fixes #12)
- `README`: added a "Running Behind A Reverse Proxy" section with a minimal Caddy config, for context in #8

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually verify: open "Add subscription", click outside the dialog, confirm it stays open and form data is preserved
- [ ] Manually verify on a mobile viewport with mobile nav enabled: open calendar, select a day with several bills, confirm the last one is fully visible/scrollable above the nav